### PR TITLE
namespace-qualify `Result` to avoid name conflicts

### DIFF
--- a/dumpster_derive/src/lib.rs
+++ b/dumpster_derive/src/lib.rs
@@ -43,7 +43,7 @@ pub fn derive_collectable(input: proc_macro::TokenStream) -> proc_macro::TokenSt
     let generated = quote! {
         unsafe impl #impl_generics dumpster::Collectable for #name #ty_generics #where_clause {
             #[inline]
-            fn accept<V: dumpster::Visitor>(&self, visitor: &mut V) -> Result<(), ()> {
+            fn accept<V: dumpster::Visitor>(&self, visitor: &mut V) -> std::result::Result<(), ()> {
                 #do_visitor
             }
         }


### PR DESCRIPTION
Specializing `Result` with a fixed error type is a common idiom in library code; with the current implementation, this causes an error since the `Result` used in the proc macro isn't qualified to the `std` namespace.