### PR TITLE
Add Gc::as_ptr

### DIFF
--- a/dumpster/src/sync/mod.rs
+++ b/dumpster/src/sync/mod.rs
@@ -50,6 +50,7 @@ use std::{
     ptr::{addr_of, drop_in_place, NonNull},
     sync::atomic::{fence, AtomicUsize, Ordering},
 };
+use std::ptr::addr_of_mut;
 
 use crate::{contains_gcs, ptr::Nullable, Collectable, Visitor};
 
@@ -344,6 +345,29 @@ where
     /// ```
     pub fn try_clone(gc: &Gc<T>) -> Option<Gc<T>> {
         unsafe { (!(*gc.ptr.get()).is_null()).then(|| gc.clone()) }
+    }
+
+    /// Provides a raw pointer to the data.
+    ///
+    /// Panics if `self` is a "dead" `Gc`,
+    /// which points to an already-deallocated object.
+    /// This can only occur if a `Gc` is accessed during the `Drop` implementation of a
+    /// [`Collectable`] object.
+    ///
+    /// # Examples
+    /// ```
+    /// use dumpster::sync::Gc;
+    /// let x = Gc::new("hello".to_owned());
+    /// let y = Gc::clone(&x);
+    /// let x_ptr = Gc::as_ptr(&x);
+    /// assert_eq!(x_ptr, Gc::as_ptr(&x));
+    /// assert_eq!(unsafe { &*x_ptr }, "hello");
+    /// ```
+    pub fn as_ptr(gc: &Gc<T>) -> *const T {
+        unsafe {
+            let ptr = NonNull::as_ptr((*gc.ptr.get()).unwrap());
+            addr_of_mut!((*ptr).value)
+        }
     }
 }
 

--- a/dumpster/src/sync/mod.rs
+++ b/dumpster/src/sync/mod.rs
@@ -355,6 +355,7 @@ where
     /// [`Collectable`] object.
     ///
     /// # Examples
+    ///
     /// ```
     /// use dumpster::sync::Gc;
     /// let x = Gc::new("hello".to_owned());

--- a/dumpster/src/sync/mod.rs
+++ b/dumpster/src/sync/mod.rs
@@ -47,10 +47,9 @@ use std::{
     cell::UnsafeCell,
     fmt::Debug,
     ops::Deref,
-    ptr::{addr_of, drop_in_place, NonNull},
+    ptr::{addr_of, addr_of_mut, drop_in_place, NonNull},
     sync::atomic::{fence, AtomicUsize, Ordering},
 };
-use std::ptr::addr_of_mut;
 
 use crate::{contains_gcs, ptr::Nullable, Collectable, Visitor};
 

--- a/dumpster/src/unsync/mod.rs
+++ b/dumpster/src/unsync/mod.rs
@@ -333,6 +333,7 @@ impl<T: Collectable + ?Sized> Gc<T> {
     /// [`Collectable`] object.
     ///
     /// # Examples
+    ///
     /// ```
     /// use dumpster::unsync::Gc;
     /// let x = Gc::new("hello".to_owned());

--- a/dumpster/src/unsync/mod.rs
+++ b/dumpster/src/unsync/mod.rs
@@ -324,6 +324,27 @@ impl<T: Collectable + ?Sized> Gc<T> {
     pub fn try_clone(gc: &Gc<T>) -> Option<Gc<T>> {
         (!gc.ptr.get().is_null()).then(|| gc.clone())
     }
+
+    /// Provides a raw pointer to the data.
+    ///
+    /// Panics if `self` is a "dead" `Gc`,
+    /// which points to an already-deallocated object.
+    /// This can only occur if a `Gc` is accessed during the `Drop` implementation of a
+    /// [`Collectable`] object.
+    ///
+    /// # Examples
+    /// ```
+    /// use dumpster::unsync::Gc;
+    /// let x = Gc::new("hello".to_owned());
+    /// let y = Gc::clone(&x);
+    /// let x_ptr = Gc::as_ptr(&x);
+    /// assert_eq!(x_ptr, Gc::as_ptr(&x));
+    /// assert_eq!(unsafe { &*x_ptr }, "hello");
+    /// ```
+    pub fn as_ptr(gc: &Gc<T>) -> *const T {
+        let ptr = NonNull::as_ptr(gc.ptr.get().unwrap());
+        unsafe { addr_of_mut!((*ptr).value) }
+    }
 }
 
 impl<T: Collectable + ?Sized> Deref for Gc<T> {

--- a/dumpster_test/src/lib.rs
+++ b/dumpster_test/src/lib.rs
@@ -160,3 +160,28 @@ fn parallel_loop() {
     assert_eq!(COUNT_3.load(Ordering::Relaxed), 1);
     assert_eq!(COUNT_4.load(Ordering::Relaxed), 1);
 }
+
+#[test]
+fn unsync_as_ptr() {
+    let empty = Gc::new(Empty);
+    let empty_a = Gc::clone(&empty);
+    let empty_ptr = Gc::as_ptr(&empty);
+    assert_eq!(empty_ptr, Gc::as_ptr(&empty_a));
+
+    #[derive(Collectable)]
+    struct B(Gc<Empty>);
+
+    let b = B(Gc::clone(&empty));
+    assert_eq!(empty_ptr, Gc::as_ptr(&b.0));
+    let bb = Gc::new(B(Gc::clone(&empty)));
+    assert_eq!(empty_ptr, Gc::as_ptr(&bb.0));
+
+    let empty2 = Gc::new(Empty);
+    let empty2_ptr = Gc::as_ptr(&empty2);
+    assert_ne!(empty_ptr, empty2_ptr);
+    let b2 = Gc::new(B(Gc::clone(&empty2)));
+    assert_eq!(empty2_ptr, Gc::as_ptr(&b2.0));
+    assert_ne!(empty_ptr, Gc::as_ptr(&b2.0));
+    assert_ne!(Gc::as_ptr(&b.0), Gc::as_ptr(&b2.0));
+    assert_ne!(Gc::as_ptr(&b.0), empty2_ptr);
+}


### PR DESCRIPTION
Closes #10 

I adapted the standalone test for `unsync::Gc::as_ptr` from [here](https://github.com/Manishearth/rust-gc/blob/9ce4e3c8d0b32053b16be9f1d27b635574259736/gc/tests/gc_semantics.rs#L294), which I also contributed. I hope that's okay.

I also didn't see a place to put a standalone test for `sync::Gc::as_ptr`, so I just left it as-is with the doc test.