### PR TITLE
Revert "Update impls.rs"

### DIFF
--- a/dumpster/src/impls.rs
+++ b/dumpster/src/impls.rs
@@ -22,7 +22,7 @@
 
 use std::{
     borrow::Cow,
-    cell::{Cell, OnceCell, RefCell, UnsafeCell},
+    cell::{Cell, OnceCell, RefCell},
     collections::{
         hash_map::{DefaultHasher, RandomState},
         BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet, LinkedList, VecDeque,
@@ -93,13 +93,6 @@ unsafe impl<T: Collectable + ?Sized> Collectable for RefCell<T> {
     #[inline]
     fn accept<V: Visitor>(&self, visitor: &mut V) -> Result<(), ()> {
         self.try_borrow().map_err(|_| ())?.accept(visitor)
-    }
-}
-
-unsafe impl<T: Collectable + ?Sized> Collectable for UnsafeCell<T> {
-    #[inline]
-    fn accept<V: Visitor>(&self, visitor: &mut V) -> Result<(), ()> {
-        unsafe { (& *self.get()).accept(visitor) }
     }
 }
 


### PR DESCRIPTION
Reverts claytonwramsey/dumpster#14

The issue I thought of was that there's no real way to use `UnsafeCell` safely with `Gc`: you use an `UnsafeCell` to get mutable access to its contents, but the `Gc` could be observing those same contents at all times.