### PR TITLE
Implement collectable for TypeId

### DIFF
--- a/dumpster/src/impls.rs
+++ b/dumpster/src/impls.rs
@@ -21,6 +21,7 @@
 #![allow(deprecated)]
 
 use std::{
+    any::TypeId,
     borrow::Cow,
     cell::{Cell, OnceCell, RefCell},
     collections::{
@@ -280,6 +281,8 @@ collectable_trivial_impl!(DefaultHasher);
 collectable_trivial_impl!(RandomState);
 collectable_trivial_impl!(Rc<str>);
 collectable_trivial_impl!(SipHasher);
+
+collectable_trivial_impl!(TypeId);
 
 /// Implement [`Collectable`] for a tuple.
 macro_rules! collectable_tuple {


### PR DESCRIPTION
This commit implements Collectable trivially for `std::any::TypeId`.

In addition to GPLv3, I additionally license this individual contribution under the Apache 2.0 license, the MIT license, and the Mozilla Public License 2.0, if this is ever needed.