### PR TITLE
Unsize coercion on stable via macros

### DIFF
--- a/dumpster/src/sync/tests.rs
+++ b/dumpster/src/sync/tests.rs
@@ -16,7 +16,7 @@ use std::{
     },
 };
 
-use crate::Visitor;
+use crate::{sync_coerce_gc, Visitor};
 
 use super::*;
 
@@ -279,6 +279,17 @@ fn eventually_collect() {
 fn coerce_array() {
     let gc1: Gc<[u8; 3]> = Gc::new([0, 0, 0]);
     let gc2: Gc<[u8]> = gc1;
+    assert_eq!(gc2.len(), 3);
+    assert_eq!(
+        std::mem::size_of::<Gc<[u8]>>(),
+        3 * std::mem::size_of::<usize>()
+    );
+}
+
+#[test]
+fn coerce_array_using_macro() {
+    let gc1: Gc<[u8; 3]> = Gc::new([0, 0, 0]);
+    let gc2: Gc<[u8]> = sync_coerce_gc!(gc1);
     assert_eq!(gc2.len(), 3);
     assert_eq!(
         std::mem::size_of::<Gc<[u8]>>(),

--- a/dumpster/src/unsync/tests.rs
+++ b/dumpster/src/unsync/tests.rs
@@ -8,7 +8,7 @@
 
 //! Simple tests using manual implementations of [`Trace`].
 
-use crate::Visitor;
+use crate::{unsync_coerce_gc, Visitor};
 
 use super::*;
 use std::{
@@ -249,6 +249,17 @@ fn double_borrow() {
 fn coerce_array() {
     let gc1: Gc<[u8; 3]> = Gc::new([0, 0, 0]);
     let gc2: Gc<[u8]> = gc1;
+    assert_eq!(gc2.len(), 3);
+    assert_eq!(
+        std::mem::size_of::<Gc<[u8]>>(),
+        2 * std::mem::size_of::<usize>()
+    );
+}
+
+#[test]
+fn coerce_array_using_macro() {
+    let gc1: Gc<[u8; 3]> = Gc::new([0, 0, 0]);
+    let gc2: Gc<[u8]> = unsync_coerce_gc!(gc1);
     assert_eq!(gc2.len(), 3);
     assert_eq!(
         std::mem::size_of::<Gc<[u8]>>(),


### PR DESCRIPTION
This PR adds two new macros, `sync_coerce_gc` and `unsync_coerce_gc`. 
They make it possible to do unsize coercions safely on stable rust:

```rust
use dumpster::{unsync::Gc, unsync_coerce_gc};

let gc1: Gc<[u8; 3]> = Gc::new([7, 8, 9]);
let gc2: Gc<[u8]> = unsync_coerce_gc!(gc1);
assert_eq!(&gc2[..], &[7, 8, 9]);
```

The trick is to temporarily convert the `Gc<T>` into its raw pointer `*const GcBox<T>`. 
This pointer can then coerce before we turn it back into the `Gc<T>`.


**Note:** To make this work I had to change `Nullable<T>` to always store a `*mut T`  because I wouldn't be able 
to get a `*mut T` from a `Option<NonNull<T>>` for `T: ?Sized`.