### PR TITLE
Add `From` implementations for `Gc`

### DIFF
--- a/dumpster/src/sync/mod.rs
+++ b/dumpster/src/sync/mod.rs
@@ -32,14 +32,15 @@ mod collect;
 mod tests;
 
 use std::{
-    alloc::{dealloc, Layout},
-    borrow::Borrow,
+    alloc::{dealloc, handle_alloc_error, Layout},
+    borrow::{Borrow, Cow},
     cell::UnsafeCell,
     fmt::Debug,
-    mem::ManuallyDrop,
+    mem::{self, ManuallyDrop},
     num::NonZeroUsize,
     ops::Deref,
-    ptr::{addr_of, addr_of_mut, drop_in_place, NonNull},
+    ptr::{self, addr_of, addr_of_mut, drop_in_place, NonNull},
+    slice,
     sync::atomic::{fence, AtomicUsize, Ordering},
 };
 
@@ -445,10 +446,10 @@ where
         unsafe { *self.ptr.get() }.is_null()
     }
 
-    /// Exists solely for the [`sync_coerce_gc`] macro.
+    /// Consumes the `Gc<T>`, returning the inner `GcBox<T>` pointer and tag.
+    #[inline]
     #[must_use]
-    #[doc(hidden)]
-    pub fn __private_into_ptr(this: Self) -> (*const GcBox<T>, usize) {
+    fn into_ptr(this: Self) -> (*const GcBox<T>, usize) {
         let this = ManuallyDrop::new(this);
         let ptr = &raw const this.ptr;
         let tag = &raw const this.tag;
@@ -457,14 +458,30 @@ where
         (ptr, tag)
     }
 
-    /// Exists solely for the [`sync_coerce_gc`] macro.
+    /// Constructs a `Gc<T>` from the innner `GcBox<T>` pointer and tag.
+    #[inline]
     #[must_use]
-    #[doc(hidden)]
-    pub unsafe fn __private_from_ptr(ptr: *const GcBox<T>, tag: usize) -> Self {
+    unsafe fn from_ptr(ptr: *const GcBox<T>, tag: usize) -> Self {
         Self {
             ptr: UnsafeCell::new(Nullable::from_ptr(ptr.cast_mut())),
             tag: AtomicUsize::new(tag),
         }
+    }
+
+    /// Exists solely for the [`sync_coerce_gc`] macro.
+    #[inline]
+    #[must_use]
+    #[doc(hidden)]
+    pub fn __private_into_ptr(this: Self) -> (*const GcBox<T>, usize) {
+        Self::into_ptr(this)
+    }
+
+    /// Exists solely for the [`sync_coerce_gc`] macro.
+    #[inline]
+    #[must_use]
+    #[doc(hidden)]
+    pub unsafe fn __private_from_ptr(ptr: *const GcBox<T>, tag: usize) -> Self {
+        Self::from_ptr(ptr, tag)
     }
 }
 
@@ -656,6 +673,52 @@ impl CollectInfo {
     }
 }
 
+impl<T: Trace + Send + Sync + ?Sized> Gc<T> {
+    /// Allocates an `GcBox<T>` with sufficient space for
+    /// a value of the provided layout.
+    ///
+    /// The function `mem_to_gc_box` is called with the data pointer
+    /// and must return back a pointer for the `GcBox<T>`.
+    unsafe fn allocate_for_layout(
+        value_layout: Layout,
+        mem_to_gc_box: impl FnOnce(*mut u8) -> *mut GcBox<T>,
+    ) -> *mut GcBox<T> {
+        let layout = Layout::new::<GcBox<()>>()
+            .extend(value_layout)
+            .unwrap()
+            .0
+            .pad_to_align();
+
+        // SAFETY: layout has non-zero size because of the `ref_count` field
+        let ptr = unsafe { std::alloc::alloc(layout) };
+
+        if ptr.is_null() {
+            handle_alloc_error(layout);
+        }
+
+        let inner = mem_to_gc_box(ptr);
+
+        unsafe {
+            (&raw mut (*inner).strong).write(AtomicUsize::new(1));
+            (&raw mut (*inner).weak).write(AtomicUsize::new(0));
+            (&raw mut (*inner).generation).write(AtomicUsize::new(0));
+        }
+
+        inner
+    }
+}
+
+impl<T: Trace + Send + Sync> Gc<[T]> {
+    /// Allocates an `GcBox<[T]>` with the given length.
+    fn allocate_for_slice(len: usize) -> *mut GcBox<[T]> {
+        unsafe {
+            Self::allocate_for_layout(Layout::array::<T>(len).unwrap(), |mem| {
+                ptr::slice_from_raw_parts_mut(mem.cast::<T>(), len) as *mut GcBox<[T]>
+            })
+        }
+    }
+}
+
 unsafe impl<T: Trace + Send + Sync + ?Sized> Trace for Gc<T> {
     fn accept<V: Visitor>(&self, visitor: &mut V) -> Result<(), ()> {
         visitor.visit_sync(self);
@@ -792,5 +855,298 @@ impl<T: Trace + Send + Sync + ?Sized> Debug for Gc<T> {
             self.ptr,
             self.tag.load(Ordering::Acquire)
         )
+    }
+}
+
+impl<T: Trace + Send + Sync> From<T> for Gc<T> {
+    /// Converts a generic type `T` into an `Gc<T>`
+    ///
+    /// The conversion allocates on the heap and moves `t`
+    /// from the stack into it.
+    ///
+    /// # Example
+    /// ```rust
+    /// # use dumpster::unsync::Gc;
+    /// let x = 5;
+    /// let rc = Gc::new(5);
+    ///
+    /// assert_eq!(Gc::from(x), rc);
+    /// ```
+    fn from(value: T) -> Self {
+        Gc::new(value)
+    }
+}
+
+impl<T: Trace + Send + Sync, const N: usize> From<[T; N]> for Gc<[T]> {
+    /// Converts a [`[T; N]`](prim@array) into an `Gc<[T]>`.
+    ///
+    /// The conversion moves the array into a newly allocated `Gc`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use dumpster::unsync::Gc;
+    /// let original: [i32; 3] = [1, 2, 3];
+    /// let shared: Gc<[i32]> = Gc::from(original);
+    /// assert_eq!(&[1, 2, 3], &shared[..]);
+    /// ```
+    #[inline]
+    fn from(v: [T; N]) -> Gc<[T]> {
+        sync_coerce_gc!(Gc::<[T; N]>::from(v))
+    }
+}
+
+impl<T: Trace + Send + Sync + Clone> From<&[T]> for Gc<[T]> {
+    /// Allocates a reference-counted slice and fills it by cloning `slice`'s items.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use dumpster::unsync::Gc;
+    /// let original: &[i32] = &[1, 2, 3];
+    /// let shared: Gc<[i32]> = Gc::from(original);
+    /// assert_eq!(&[1, 2, 3], &shared[..]);
+    /// ```
+    #[inline]
+    fn from(slice: &[T]) -> Gc<[T]> {
+        // Panic guard while cloning T elements.
+        // In the event of a panic, elements that have been written
+        // into the new GcBox will be dropped, then the memory freed.
+        struct Guard<T> {
+            /// pointer to `GcBox` to deallocate on panic
+            mem: *mut u8,
+            /// layout of the `GcBox` to deallocate on panic
+            layout: Layout,
+            /// pointer to the `GcBox`'s value
+            elems: *mut T,
+            /// the number of elements cloned so far
+            n_elems: usize,
+        }
+
+        impl<T> Drop for Guard<T> {
+            fn drop(&mut self) {
+                unsafe {
+                    let slice = slice::from_raw_parts_mut(self.elems, self.n_elems);
+                    ptr::drop_in_place(slice);
+
+                    dealloc(self.mem, self.layout);
+                }
+            }
+        }
+
+        unsafe {
+            let layout = Layout::array::<T>(slice.len()).unwrap();
+
+            let ptr = Self::allocate_for_layout(Layout::array::<T>(slice.len()).unwrap(), |mem| {
+                ptr::slice_from_raw_parts_mut(mem.cast::<T>(), slice.len()) as *mut GcBox<[T]>
+            });
+
+            // Pointer to first element
+            let elems = (&raw mut (*ptr).value).cast::<T>();
+
+            let mut guard = Guard {
+                mem: ptr.cast::<u8>(),
+                elems,
+                layout,
+                n_elems: 0,
+            };
+
+            for (i, item) in slice.iter().enumerate() {
+                ptr::write(elems.add(i), item.clone());
+                guard.n_elems += 1;
+            }
+
+            // All clear. Forget the guard so it doesn't free the new GcBox.
+            mem::forget(guard);
+
+            notify_created_gc();
+
+            Self {
+                ptr: UnsafeCell::new(Nullable::from_ptr(ptr)),
+                tag: AtomicUsize::new(0),
+            }
+        }
+    }
+}
+
+impl<T: Trace + Send + Sync + Clone> From<&mut [T]> for Gc<[T]> {
+    /// Allocates a garbage-collected slice and fills it by cloning `v`'s items.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use dumpster::unsync::Gc;
+    /// let mut original = [1, 2, 3];
+    /// let original: &mut [i32] = &mut original;
+    /// let shared: Gc<[i32]> = Gc::from(original);
+    /// assert_eq!(&[1, 2, 3], &shared[..]);
+    /// ```
+    #[inline]
+    fn from(value: &mut [T]) -> Self {
+        Gc::from(&*value)
+    }
+}
+
+impl From<&str> for Gc<str> {
+    /// Allocates a garbage-collected string slice and copies `v` into it.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use dumpster::unsync::Gc;
+    /// let shared: Gc<str> = Gc::from("statue");
+    /// assert_eq!("statue", &shared[..]);
+    /// ```
+    #[inline]
+    fn from(v: &str) -> Self {
+        let bytes = Gc::<[u8]>::from(v.as_bytes());
+        let (ptr, tag) = Gc::into_ptr(bytes);
+        unsafe { Gc::from_ptr(ptr as *const GcBox<str>, tag) }
+    }
+}
+
+impl From<&mut str> for Gc<str> {
+    /// Allocates a garbage-collected string slice and copies `v` into it.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use dumpster::unsync::Gc;
+    /// let mut original = String::from("statue");
+    /// let original: &mut str = &mut original;
+    /// let shared: Gc<str> = Gc::from(original);
+    /// assert_eq!("statue", &shared[..]);
+    /// ```
+    #[inline]
+    fn from(v: &mut str) -> Self {
+        Gc::from(&*v)
+    }
+}
+
+impl From<Gc<str>> for Gc<[u8]> {
+    /// Converts a garbage-collected string slice into a byte slice.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use dumpster::unsync::Gc;
+    /// let string: Gc<str> = Gc::from("eggplant");
+    /// let bytes: Gc<[u8]> = Gc::from(string);
+    /// assert_eq!("eggplant".as_bytes(), bytes.as_ref());
+    /// ```
+    #[inline]
+    fn from(value: Gc<str>) -> Self {
+        let (ptr, tag) = Gc::into_ptr(value);
+        unsafe { Gc::from_ptr(ptr as *const GcBox<[u8]>, tag) }
+    }
+}
+
+impl From<String> for Gc<str> {
+    /// Allocates a garbage-collected string slice and copies `v` into it.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use dumpster::unsync::Gc;
+    /// let original: String = "statue".to_owned();
+    /// let shared: Gc<str> = Gc::from(original);
+    /// assert_eq!("statue", &shared[..]);
+    /// ```
+    #[inline]
+    fn from(value: String) -> Self {
+        Self::from(&value[..])
+    }
+}
+
+impl<T: Trace + Send + Sync> From<Box<T>> for Gc<T> {
+    /// Move a boxed object to a new, reference counted, allocation.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use std::rc::Rc;
+    /// let original: Box<i32> = Box::new(1);
+    /// let shared: Rc<i32> = Rc::from(original);
+    /// assert_eq!(1, *shared);
+    /// ```
+    #[inline]
+    fn from(src: Box<T>) -> Self {
+        unsafe {
+            let layout = Layout::for_value(&*src);
+            let gc_ptr = Gc::allocate_for_layout(layout, <*mut u8>::cast::<GcBox<T>>);
+
+            // Copy value as bytes
+            ptr::copy_nonoverlapping(
+                (&raw const *src).cast::<u8>(),
+                (&raw mut (*gc_ptr).value).cast::<u8>(),
+                layout.size(),
+            );
+
+            // Free the allocation without dropping its contents
+            let bptr = Box::into_raw(src);
+            let src = Box::from_raw(bptr.cast::<mem::ManuallyDrop<T>>());
+            drop(src);
+
+            notify_created_gc();
+            Self::from_ptr(gc_ptr, 0)
+        }
+    }
+}
+
+impl<T: Trace + Send + Sync> From<Vec<T>> for Gc<[T]> {
+    /// Allocates a garbage-collected slice and moves `vec`'s items into it.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use dumpster::unsync::Gc;
+    /// let unique: Vec<i32> = vec![1, 2, 3];
+    /// let shared: Gc<[i32]> = Gc::from(unique);
+    /// assert_eq!(&[1, 2, 3], &shared[..]);
+    /// ```
+    #[inline]
+    fn from(vec: Vec<T>) -> Self {
+        let mut vec = ManuallyDrop::new(vec);
+        let vec_cap = vec.capacity();
+        let vec_len = vec.len();
+        let vec_ptr = vec.as_mut_ptr();
+
+        let gc_ptr = Self::allocate_for_slice(vec_len);
+
+        unsafe {
+            let dst_ptr = (&raw mut (*gc_ptr).value).cast::<T>();
+            ptr::copy_nonoverlapping(vec_ptr, dst_ptr, vec_len);
+
+            let _ = Vec::from_raw_parts(vec_ptr, 0, vec_cap);
+
+            notify_created_gc();
+            Self::from_ptr(gc_ptr, 0)
+        }
+    }
+}
+
+impl<'a, B: Trace + Send + Sync> From<Cow<'a, B>> for Gc<B>
+where
+    B: ToOwned + ?Sized,
+    Gc<B>: From<&'a B> + From<B::Owned>,
+{
+    /// Creates a reference-counted pointer from a clone-on-write pointer by
+    /// copying its content.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use dumpster::unsync::Gc;
+    /// # use std::borrow::Cow;
+    /// let cow: Cow<'_, str> = Cow::Borrowed("eggplant");
+    /// let shared: Gc<str> = Gc::from(cow);
+    /// assert_eq!("eggplant", &shared[..]);
+    /// ```
+    #[inline]
+    fn from(cow: Cow<'a, B>) -> Gc<B> {
+        match cow {
+            Cow::Borrowed(s) => Gc::from(s),
+            Cow::Owned(s) => Gc::from(s),
+        }
     }
 }

--- a/dumpster/src/sync/mod.rs
+++ b/dumpster/src/sync/mod.rs
@@ -858,295 +858,304 @@ impl<T: Trace + Send + Sync + ?Sized> Debug for Gc<T> {
     }
 }
 
-impl<T: Trace + Send + Sync> From<T> for Gc<T> {
-    /// Converts a generic type `T` into an `Gc<T>`
-    ///
-    /// The conversion allocates on the heap and moves `t`
-    /// from the stack into it.
-    ///
-    /// # Example
-    /// ```rust
-    /// # use dumpster::unsync::Gc;
-    /// let x = 5;
-    /// let rc = Gc::new(5);
-    ///
-    /// assert_eq!(Gc::from(x), rc);
-    /// ```
-    fn from(value: T) -> Self {
-        Gc::new(value)
-    }
-}
+/// The code in the below module is derived from the implementations for [`std::sync::Arc`] found in the [Rust standard library](https://github.com/rust-lang/rust).
+/// The original implementation was published under both the [MIT](https://mit-license.org/) and [Apache license](http://www.apache.org/licenses/LICENSE-2.0), version 2.0.
+/// Copies of the licenses are available at the linked addresses.
+mod from {
+    use super::*;
 
-impl<T: Trace + Send + Sync, const N: usize> From<[T; N]> for Gc<[T]> {
-    /// Converts a [`[T; N]`](prim@array) into an `Gc<[T]>`.
-    ///
-    /// The conversion moves the array into a newly allocated `Gc`.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use dumpster::unsync::Gc;
-    /// let original: [i32; 3] = [1, 2, 3];
-    /// let shared: Gc<[i32]> = Gc::from(original);
-    /// assert_eq!(&[1, 2, 3], &shared[..]);
-    /// ```
-    #[inline]
-    fn from(v: [T; N]) -> Gc<[T]> {
-        sync_coerce_gc!(Gc::<[T; N]>::from(v))
-    }
-}
-
-impl<T: Trace + Send + Sync + Clone> From<&[T]> for Gc<[T]> {
-    /// Allocates a reference-counted slice and fills it by cloning `slice`'s items.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use dumpster::unsync::Gc;
-    /// let original: &[i32] = &[1, 2, 3];
-    /// let shared: Gc<[i32]> = Gc::from(original);
-    /// assert_eq!(&[1, 2, 3], &shared[..]);
-    /// ```
-    #[inline]
-    fn from(slice: &[T]) -> Gc<[T]> {
-        // Panic guard while cloning T elements.
-        // In the event of a panic, elements that have been written
-        // into the new GcBox will be dropped, then the memory freed.
-        struct Guard<T> {
-            /// pointer to `GcBox` to deallocate on panic
-            mem: *mut u8,
-            /// layout of the `GcBox` to deallocate on panic
-            layout: Layout,
-            /// pointer to the `GcBox`'s value
-            elems: *mut T,
-            /// the number of elements cloned so far
-            n_elems: usize,
+    impl<T: Trace + Send + Sync> From<T> for Gc<T> {
+        /// Converts a generic type `T` into an `Gc<T>`
+        ///
+        /// The conversion allocates on the heap and moves `t`
+        /// from the stack into it.
+        ///
+        /// # Example
+        /// ```rust
+        /// # use dumpster::unsync::Gc;
+        /// let x = 5;
+        /// let rc = Gc::new(5);
+        ///
+        /// assert_eq!(Gc::from(x), rc);
+        /// ```
+        fn from(value: T) -> Self {
+            Gc::new(value)
         }
+    }
 
-        impl<T> Drop for Guard<T> {
-            fn drop(&mut self) {
-                unsafe {
-                    let slice = slice::from_raw_parts_mut(self.elems, self.n_elems);
-                    ptr::drop_in_place(slice);
+    impl<T: Trace + Send + Sync, const N: usize> From<[T; N]> for Gc<[T]> {
+        /// Converts a [`[T; N]`](prim@array) into an `Gc<[T]>`.
+        ///
+        /// The conversion moves the array into a newly allocated `Gc`.
+        ///
+        /// # Example
+        ///
+        /// ```
+        /// # use dumpster::unsync::Gc;
+        /// let original: [i32; 3] = [1, 2, 3];
+        /// let shared: Gc<[i32]> = Gc::from(original);
+        /// assert_eq!(&[1, 2, 3], &shared[..]);
+        /// ```
+        #[inline]
+        fn from(v: [T; N]) -> Gc<[T]> {
+            sync_coerce_gc!(Gc::<[T; N]>::from(v))
+        }
+    }
 
-                    dealloc(self.mem, self.layout);
+    impl<T: Trace + Send + Sync + Clone> From<&[T]> for Gc<[T]> {
+        /// Allocates a reference-counted slice and fills it by cloning `slice`'s items.
+        ///
+        /// # Example
+        ///
+        /// ```
+        /// # use dumpster::unsync::Gc;
+        /// let original: &[i32] = &[1, 2, 3];
+        /// let shared: Gc<[i32]> = Gc::from(original);
+        /// assert_eq!(&[1, 2, 3], &shared[..]);
+        /// ```
+        #[inline]
+        fn from(slice: &[T]) -> Gc<[T]> {
+            // Panic guard while cloning T elements.
+            // In the event of a panic, elements that have been written
+            // into the new GcBox will be dropped, then the memory freed.
+            struct Guard<T> {
+                /// pointer to `GcBox` to deallocate on panic
+                mem: *mut u8,
+                /// layout of the `GcBox` to deallocate on panic
+                layout: Layout,
+                /// pointer to the `GcBox`'s value
+                elems: *mut T,
+                /// the number of elements cloned so far
+                n_elems: usize,
+            }
+
+            impl<T> Drop for Guard<T> {
+                fn drop(&mut self) {
+                    unsafe {
+                        let slice = slice::from_raw_parts_mut(self.elems, self.n_elems);
+                        ptr::drop_in_place(slice);
+
+                        dealloc(self.mem, self.layout);
+                    }
+                }
+            }
+
+            unsafe {
+                let layout = Layout::array::<T>(slice.len()).unwrap();
+
+                let ptr =
+                    Self::allocate_for_layout(Layout::array::<T>(slice.len()).unwrap(), |mem| {
+                        ptr::slice_from_raw_parts_mut(mem.cast::<T>(), slice.len())
+                            as *mut GcBox<[T]>
+                    });
+
+                // Pointer to first element
+                let elems = (&raw mut (*ptr).value).cast::<T>();
+
+                let mut guard = Guard {
+                    mem: ptr.cast::<u8>(),
+                    elems,
+                    layout,
+                    n_elems: 0,
+                };
+
+                for (i, item) in slice.iter().enumerate() {
+                    ptr::write(elems.add(i), item.clone());
+                    guard.n_elems += 1;
+                }
+
+                // All clear. Forget the guard so it doesn't free the new GcBox.
+                mem::forget(guard);
+
+                notify_created_gc();
+
+                Self {
+                    ptr: UnsafeCell::new(Nullable::from_ptr(ptr)),
+                    tag: AtomicUsize::new(0),
                 }
             }
         }
+    }
 
-        unsafe {
-            let layout = Layout::array::<T>(slice.len()).unwrap();
+    impl<T: Trace + Send + Sync + Clone> From<&mut [T]> for Gc<[T]> {
+        /// Allocates a garbage-collected slice and fills it by cloning `v`'s items.
+        ///
+        /// # Example
+        ///
+        /// ```
+        /// # use dumpster::unsync::Gc;
+        /// let mut original = [1, 2, 3];
+        /// let original: &mut [i32] = &mut original;
+        /// let shared: Gc<[i32]> = Gc::from(original);
+        /// assert_eq!(&[1, 2, 3], &shared[..]);
+        /// ```
+        #[inline]
+        fn from(value: &mut [T]) -> Self {
+            Gc::from(&*value)
+        }
+    }
 
-            let ptr = Self::allocate_for_layout(Layout::array::<T>(slice.len()).unwrap(), |mem| {
-                ptr::slice_from_raw_parts_mut(mem.cast::<T>(), slice.len()) as *mut GcBox<[T]>
-            });
+    impl From<&str> for Gc<str> {
+        /// Allocates a garbage-collected string slice and copies `v` into it.
+        ///
+        /// # Example
+        ///
+        /// ```
+        /// # use dumpster::unsync::Gc;
+        /// let shared: Gc<str> = Gc::from("statue");
+        /// assert_eq!("statue", &shared[..]);
+        /// ```
+        #[inline]
+        fn from(v: &str) -> Self {
+            let bytes = Gc::<[u8]>::from(v.as_bytes());
+            let (ptr, tag) = Gc::into_ptr(bytes);
+            unsafe { Gc::from_ptr(ptr as *const GcBox<str>, tag) }
+        }
+    }
 
-            // Pointer to first element
-            let elems = (&raw mut (*ptr).value).cast::<T>();
+    impl From<&mut str> for Gc<str> {
+        /// Allocates a garbage-collected string slice and copies `v` into it.
+        ///
+        /// # Example
+        ///
+        /// ```
+        /// # use dumpster::unsync::Gc;
+        /// let mut original = String::from("statue");
+        /// let original: &mut str = &mut original;
+        /// let shared: Gc<str> = Gc::from(original);
+        /// assert_eq!("statue", &shared[..]);
+        /// ```
+        #[inline]
+        fn from(v: &mut str) -> Self {
+            Gc::from(&*v)
+        }
+    }
 
-            let mut guard = Guard {
-                mem: ptr.cast::<u8>(),
-                elems,
-                layout,
-                n_elems: 0,
-            };
+    impl From<Gc<str>> for Gc<[u8]> {
+        /// Converts a garbage-collected string slice into a byte slice.
+        ///
+        /// # Example
+        ///
+        /// ```
+        /// # use dumpster::unsync::Gc;
+        /// let string: Gc<str> = Gc::from("eggplant");
+        /// let bytes: Gc<[u8]> = Gc::from(string);
+        /// assert_eq!("eggplant".as_bytes(), bytes.as_ref());
+        /// ```
+        #[inline]
+        fn from(value: Gc<str>) -> Self {
+            let (ptr, tag) = Gc::into_ptr(value);
+            unsafe { Gc::from_ptr(ptr as *const GcBox<[u8]>, tag) }
+        }
+    }
 
-            for (i, item) in slice.iter().enumerate() {
-                ptr::write(elems.add(i), item.clone());
-                guard.n_elems += 1;
+    impl From<String> for Gc<str> {
+        /// Allocates a garbage-collected string slice and copies `v` into it.
+        ///
+        /// # Example
+        ///
+        /// ```
+        /// # use dumpster::unsync::Gc;
+        /// let original: String = "statue".to_owned();
+        /// let shared: Gc<str> = Gc::from(original);
+        /// assert_eq!("statue", &shared[..]);
+        /// ```
+        #[inline]
+        fn from(value: String) -> Self {
+            Self::from(&value[..])
+        }
+    }
+
+    impl<T: Trace + Send + Sync> From<Box<T>> for Gc<T> {
+        /// Move a boxed object to a new, reference counted, allocation.
+        ///
+        /// # Example
+        ///
+        /// ```
+        /// # use std::rc::Rc;
+        /// let original: Box<i32> = Box::new(1);
+        /// let shared: Rc<i32> = Rc::from(original);
+        /// assert_eq!(1, *shared);
+        /// ```
+        #[inline]
+        fn from(src: Box<T>) -> Self {
+            unsafe {
+                let layout = Layout::for_value(&*src);
+                let gc_ptr = Gc::allocate_for_layout(layout, <*mut u8>::cast::<GcBox<T>>);
+
+                // Copy value as bytes
+                ptr::copy_nonoverlapping(
+                    (&raw const *src).cast::<u8>(),
+                    (&raw mut (*gc_ptr).value).cast::<u8>(),
+                    layout.size(),
+                );
+
+                // Free the allocation without dropping its contents
+                let bptr = Box::into_raw(src);
+                let src = Box::from_raw(bptr.cast::<mem::ManuallyDrop<T>>());
+                drop(src);
+
+                notify_created_gc();
+                Self::from_ptr(gc_ptr, 0)
             }
+        }
+    }
 
-            // All clear. Forget the guard so it doesn't free the new GcBox.
-            mem::forget(guard);
+    impl<T: Trace + Send + Sync> From<Vec<T>> for Gc<[T]> {
+        /// Allocates a garbage-collected slice and moves `vec`'s items into it.
+        ///
+        /// # Example
+        ///
+        /// ```
+        /// # use dumpster::unsync::Gc;
+        /// let unique: Vec<i32> = vec![1, 2, 3];
+        /// let shared: Gc<[i32]> = Gc::from(unique);
+        /// assert_eq!(&[1, 2, 3], &shared[..]);
+        /// ```
+        #[inline]
+        fn from(vec: Vec<T>) -> Self {
+            let mut vec = ManuallyDrop::new(vec);
+            let vec_cap = vec.capacity();
+            let vec_len = vec.len();
+            let vec_ptr = vec.as_mut_ptr();
 
-            notify_created_gc();
+            let gc_ptr = Self::allocate_for_slice(vec_len);
 
-            Self {
-                ptr: UnsafeCell::new(Nullable::from_ptr(ptr)),
-                tag: AtomicUsize::new(0),
+            unsafe {
+                let dst_ptr = (&raw mut (*gc_ptr).value).cast::<T>();
+                ptr::copy_nonoverlapping(vec_ptr, dst_ptr, vec_len);
+
+                let _ = Vec::from_raw_parts(vec_ptr, 0, vec_cap);
+
+                notify_created_gc();
+                Self::from_ptr(gc_ptr, 0)
             }
         }
     }
-}
 
-impl<T: Trace + Send + Sync + Clone> From<&mut [T]> for Gc<[T]> {
-    /// Allocates a garbage-collected slice and fills it by cloning `v`'s items.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use dumpster::unsync::Gc;
-    /// let mut original = [1, 2, 3];
-    /// let original: &mut [i32] = &mut original;
-    /// let shared: Gc<[i32]> = Gc::from(original);
-    /// assert_eq!(&[1, 2, 3], &shared[..]);
-    /// ```
-    #[inline]
-    fn from(value: &mut [T]) -> Self {
-        Gc::from(&*value)
-    }
-}
-
-impl From<&str> for Gc<str> {
-    /// Allocates a garbage-collected string slice and copies `v` into it.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use dumpster::unsync::Gc;
-    /// let shared: Gc<str> = Gc::from("statue");
-    /// assert_eq!("statue", &shared[..]);
-    /// ```
-    #[inline]
-    fn from(v: &str) -> Self {
-        let bytes = Gc::<[u8]>::from(v.as_bytes());
-        let (ptr, tag) = Gc::into_ptr(bytes);
-        unsafe { Gc::from_ptr(ptr as *const GcBox<str>, tag) }
-    }
-}
-
-impl From<&mut str> for Gc<str> {
-    /// Allocates a garbage-collected string slice and copies `v` into it.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use dumpster::unsync::Gc;
-    /// let mut original = String::from("statue");
-    /// let original: &mut str = &mut original;
-    /// let shared: Gc<str> = Gc::from(original);
-    /// assert_eq!("statue", &shared[..]);
-    /// ```
-    #[inline]
-    fn from(v: &mut str) -> Self {
-        Gc::from(&*v)
-    }
-}
-
-impl From<Gc<str>> for Gc<[u8]> {
-    /// Converts a garbage-collected string slice into a byte slice.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use dumpster::unsync::Gc;
-    /// let string: Gc<str> = Gc::from("eggplant");
-    /// let bytes: Gc<[u8]> = Gc::from(string);
-    /// assert_eq!("eggplant".as_bytes(), bytes.as_ref());
-    /// ```
-    #[inline]
-    fn from(value: Gc<str>) -> Self {
-        let (ptr, tag) = Gc::into_ptr(value);
-        unsafe { Gc::from_ptr(ptr as *const GcBox<[u8]>, tag) }
-    }
-}
-
-impl From<String> for Gc<str> {
-    /// Allocates a garbage-collected string slice and copies `v` into it.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use dumpster::unsync::Gc;
-    /// let original: String = "statue".to_owned();
-    /// let shared: Gc<str> = Gc::from(original);
-    /// assert_eq!("statue", &shared[..]);
-    /// ```
-    #[inline]
-    fn from(value: String) -> Self {
-        Self::from(&value[..])
-    }
-}
-
-impl<T: Trace + Send + Sync> From<Box<T>> for Gc<T> {
-    /// Move a boxed object to a new, reference counted, allocation.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use std::rc::Rc;
-    /// let original: Box<i32> = Box::new(1);
-    /// let shared: Rc<i32> = Rc::from(original);
-    /// assert_eq!(1, *shared);
-    /// ```
-    #[inline]
-    fn from(src: Box<T>) -> Self {
-        unsafe {
-            let layout = Layout::for_value(&*src);
-            let gc_ptr = Gc::allocate_for_layout(layout, <*mut u8>::cast::<GcBox<T>>);
-
-            // Copy value as bytes
-            ptr::copy_nonoverlapping(
-                (&raw const *src).cast::<u8>(),
-                (&raw mut (*gc_ptr).value).cast::<u8>(),
-                layout.size(),
-            );
-
-            // Free the allocation without dropping its contents
-            let bptr = Box::into_raw(src);
-            let src = Box::from_raw(bptr.cast::<mem::ManuallyDrop<T>>());
-            drop(src);
-
-            notify_created_gc();
-            Self::from_ptr(gc_ptr, 0)
-        }
-    }
-}
-
-impl<T: Trace + Send + Sync> From<Vec<T>> for Gc<[T]> {
-    /// Allocates a garbage-collected slice and moves `vec`'s items into it.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use dumpster::unsync::Gc;
-    /// let unique: Vec<i32> = vec![1, 2, 3];
-    /// let shared: Gc<[i32]> = Gc::from(unique);
-    /// assert_eq!(&[1, 2, 3], &shared[..]);
-    /// ```
-    #[inline]
-    fn from(vec: Vec<T>) -> Self {
-        let mut vec = ManuallyDrop::new(vec);
-        let vec_cap = vec.capacity();
-        let vec_len = vec.len();
-        let vec_ptr = vec.as_mut_ptr();
-
-        let gc_ptr = Self::allocate_for_slice(vec_len);
-
-        unsafe {
-            let dst_ptr = (&raw mut (*gc_ptr).value).cast::<T>();
-            ptr::copy_nonoverlapping(vec_ptr, dst_ptr, vec_len);
-
-            let _ = Vec::from_raw_parts(vec_ptr, 0, vec_cap);
-
-            notify_created_gc();
-            Self::from_ptr(gc_ptr, 0)
-        }
-    }
-}
-
-impl<'a, B: Trace + Send + Sync> From<Cow<'a, B>> for Gc<B>
-where
-    B: ToOwned + ?Sized,
-    Gc<B>: From<&'a B> + From<B::Owned>,
-{
-    /// Creates a reference-counted pointer from a clone-on-write pointer by
-    /// copying its content.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// # use dumpster::unsync::Gc;
-    /// # use std::borrow::Cow;
-    /// let cow: Cow<'_, str> = Cow::Borrowed("eggplant");
-    /// let shared: Gc<str> = Gc::from(cow);
-    /// assert_eq!("eggplant", &shared[..]);
-    /// ```
-    #[inline]
-    fn from(cow: Cow<'a, B>) -> Gc<B> {
-        match cow {
-            Cow::Borrowed(s) => Gc::from(s),
-            Cow::Owned(s) => Gc::from(s),
+    impl<'a, B: Trace + Send + Sync> From<Cow<'a, B>> for Gc<B>
+    where
+        B: ToOwned + ?Sized,
+        Gc<B>: From<&'a B> + From<B::Owned>,
+    {
+        /// Creates a reference-counted pointer from a clone-on-write pointer by
+        /// copying its content.
+        ///
+        /// # Example
+        ///
+        /// ```rust
+        /// # use dumpster::unsync::Gc;
+        /// # use std::borrow::Cow;
+        /// let cow: Cow<'_, str> = Cow::Borrowed("eggplant");
+        /// let shared: Gc<str> = Gc::from(cow);
+        /// assert_eq!("eggplant", &shared[..]);
+        /// ```
+        #[inline]
+        fn from(cow: Cow<'a, B>) -> Gc<B> {
+            match cow {
+                Cow::Borrowed(s) => Gc::from(s),
+                Cow::Owned(s) => Gc::from(s),
+            }
         }
     }
 }

--- a/dumpster/src/unsync/mod.rs
+++ b/dumpster/src/unsync/mod.rs
@@ -816,292 +816,301 @@ where
 {
 }
 
-impl<T: Trace> From<T> for Gc<T> {
-    /// Converts a generic type `T` into an `Gc<T>`
-    ///
-    /// The conversion allocates on the heap and moves `t`
-    /// from the stack into it.
-    ///
-    /// # Example
-    /// ```rust
-    /// # use dumpster::unsync::Gc;
-    /// let x = 5;
-    /// let rc = Gc::new(5);
-    ///
-    /// assert_eq!(Gc::from(x), rc);
-    /// ```
-    fn from(value: T) -> Self {
-        Gc::new(value)
-    }
-}
+/// The code in the below module is derived from the implementations for [`std::rc::Rc`] found in the [Rust standard library](https://github.com/rust-lang/rust).
+/// The original implementation was published under both the [MIT](https://mit-license.org/) and [Apache license](http://www.apache.org/licenses/LICENSE-2.0), version 2.0.
+/// Copies of the licenses are available at the linked addresses.
+mod from {
+    use super::*;
 
-impl<T: Trace, const N: usize> From<[T; N]> for Gc<[T]> {
-    /// Converts a [`[T; N]`](prim@array) into an `Gc<[T]>`.
-    ///
-    /// The conversion moves the array into a newly allocated `Gc`.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use dumpster::unsync::Gc;
-    /// let original: [i32; 3] = [1, 2, 3];
-    /// let shared: Gc<[i32]> = Gc::from(original);
-    /// assert_eq!(&[1, 2, 3], &shared[..]);
-    /// ```
-    #[inline]
-    fn from(v: [T; N]) -> Gc<[T]> {
-        unsync_coerce_gc!(Gc::<[T; N]>::from(v))
-    }
-}
-
-impl<T: Trace + Clone> From<&[T]> for Gc<[T]> {
-    /// Allocates a reference-counted slice and fills it by cloning `slice`'s items.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use dumpster::unsync::Gc;
-    /// let original: &[i32] = &[1, 2, 3];
-    /// let shared: Gc<[i32]> = Gc::from(original);
-    /// assert_eq!(&[1, 2, 3], &shared[..]);
-    /// ```
-    #[inline]
-    fn from(slice: &[T]) -> Gc<[T]> {
-        // Panic guard while cloning T elements.
-        // In the event of a panic, elements that have been written
-        // into the new GcBox will be dropped, then the memory freed.
-        struct Guard<T> {
-            /// pointer to `GcBox` to deallocate on panic
-            mem: *mut u8,
-            /// layout of the `GcBox` to deallocate on panic
-            layout: Layout,
-            /// pointer to the `GcBox`'s value
-            elems: *mut T,
-            /// the number of elements cloned so far
-            n_elems: usize,
+    impl<T: Trace> From<T> for Gc<T> {
+        /// Converts a generic type `T` into an `Gc<T>`
+        ///
+        /// The conversion allocates on the heap and moves `t`
+        /// from the stack into it.
+        ///
+        /// # Example
+        /// ```rust
+        /// # use dumpster::unsync::Gc;
+        /// let x = 5;
+        /// let rc = Gc::new(5);
+        ///
+        /// assert_eq!(Gc::from(x), rc);
+        /// ```
+        fn from(value: T) -> Self {
+            Gc::new(value)
         }
+    }
 
-        impl<T> Drop for Guard<T> {
-            fn drop(&mut self) {
-                unsafe {
-                    let slice = slice::from_raw_parts_mut(self.elems, self.n_elems);
-                    ptr::drop_in_place(slice);
+    impl<T: Trace, const N: usize> From<[T; N]> for Gc<[T]> {
+        /// Converts a [`[T; N]`](prim@array) into an `Gc<[T]>`.
+        ///
+        /// The conversion moves the array into a newly allocated `Gc`.
+        ///
+        /// # Example
+        ///
+        /// ```
+        /// # use dumpster::unsync::Gc;
+        /// let original: [i32; 3] = [1, 2, 3];
+        /// let shared: Gc<[i32]> = Gc::from(original);
+        /// assert_eq!(&[1, 2, 3], &shared[..]);
+        /// ```
+        #[inline]
+        fn from(v: [T; N]) -> Gc<[T]> {
+            unsync_coerce_gc!(Gc::<[T; N]>::from(v))
+        }
+    }
 
-                    dealloc(self.mem, self.layout);
+    impl<T: Trace + Clone> From<&[T]> for Gc<[T]> {
+        /// Allocates a reference-counted slice and fills it by cloning `slice`'s items.
+        ///
+        /// # Example
+        ///
+        /// ```
+        /// # use dumpster::unsync::Gc;
+        /// let original: &[i32] = &[1, 2, 3];
+        /// let shared: Gc<[i32]> = Gc::from(original);
+        /// assert_eq!(&[1, 2, 3], &shared[..]);
+        /// ```
+        #[inline]
+        fn from(slice: &[T]) -> Gc<[T]> {
+            // Panic guard while cloning T elements.
+            // In the event of a panic, elements that have been written
+            // into the new GcBox will be dropped, then the memory freed.
+            struct Guard<T> {
+                /// pointer to `GcBox` to deallocate on panic
+                mem: *mut u8,
+                /// layout of the `GcBox` to deallocate on panic
+                layout: Layout,
+                /// pointer to the `GcBox`'s value
+                elems: *mut T,
+                /// the number of elements cloned so far
+                n_elems: usize,
+            }
+
+            impl<T> Drop for Guard<T> {
+                fn drop(&mut self) {
+                    unsafe {
+                        let slice = slice::from_raw_parts_mut(self.elems, self.n_elems);
+                        ptr::drop_in_place(slice);
+
+                        dealloc(self.mem, self.layout);
+                    }
+                }
+            }
+
+            unsafe {
+                let layout = Layout::array::<T>(slice.len()).unwrap();
+
+                let ptr =
+                    Self::allocate_for_layout(Layout::array::<T>(slice.len()).unwrap(), |mem| {
+                        ptr::slice_from_raw_parts_mut(mem.cast::<T>(), slice.len())
+                            as *mut GcBox<[T]>
+                    });
+
+                // Pointer to first element
+                let elems = (&raw mut (*ptr).value).cast::<T>();
+
+                let mut guard = Guard {
+                    mem: ptr.cast::<u8>(),
+                    elems,
+                    layout,
+                    n_elems: 0,
+                };
+
+                for (i, item) in slice.iter().enumerate() {
+                    ptr::write(elems.add(i), item.clone());
+                    guard.n_elems += 1;
+                }
+
+                // All clear. Forget the guard so it doesn't free the new GcBox.
+                mem::forget(guard);
+
+                DUMPSTER.with(Dumpster::notify_created_gc);
+
+                Self {
+                    ptr: Cell::new(Nullable::from_ptr(ptr)),
                 }
             }
         }
+    }
 
-        unsafe {
-            let layout = Layout::array::<T>(slice.len()).unwrap();
+    impl<T: Trace + Clone> From<&mut [T]> for Gc<[T]> {
+        /// Allocates a garbage-collected slice and fills it by cloning `v`'s items.
+        ///
+        /// # Example
+        ///
+        /// ```
+        /// # use dumpster::unsync::Gc;
+        /// let mut original = [1, 2, 3];
+        /// let original: &mut [i32] = &mut original;
+        /// let shared: Gc<[i32]> = Gc::from(original);
+        /// assert_eq!(&[1, 2, 3], &shared[..]);
+        /// ```
+        #[inline]
+        fn from(value: &mut [T]) -> Self {
+            Gc::from(&*value)
+        }
+    }
 
-            let ptr = Self::allocate_for_layout(Layout::array::<T>(slice.len()).unwrap(), |mem| {
-                ptr::slice_from_raw_parts_mut(mem.cast::<T>(), slice.len()) as *mut GcBox<[T]>
-            });
+    impl From<&str> for Gc<str> {
+        /// Allocates a garbage-collected string slice and copies `v` into it.
+        ///
+        /// # Example
+        ///
+        /// ```
+        /// # use dumpster::unsync::Gc;
+        /// let shared: Gc<str> = Gc::from("statue");
+        /// assert_eq!("statue", &shared[..]);
+        /// ```
+        #[inline]
+        fn from(v: &str) -> Self {
+            let bytes = Gc::<[u8]>::from(v.as_bytes());
+            unsafe { Gc::from_ptr(Gc::into_ptr(bytes) as *const GcBox<str>) }
+        }
+    }
 
-            // Pointer to first element
-            let elems = (&raw mut (*ptr).value).cast::<T>();
+    impl From<&mut str> for Gc<str> {
+        /// Allocates a garbage-collected string slice and copies `v` into it.
+        ///
+        /// # Example
+        ///
+        /// ```
+        /// # use dumpster::unsync::Gc;
+        /// let mut original = String::from("statue");
+        /// let original: &mut str = &mut original;
+        /// let shared: Gc<str> = Gc::from(original);
+        /// assert_eq!("statue", &shared[..]);
+        /// ```
+        #[inline]
+        fn from(v: &mut str) -> Self {
+            Gc::from(&*v)
+        }
+    }
 
-            let mut guard = Guard {
-                mem: ptr.cast::<u8>(),
-                elems,
-                layout,
-                n_elems: 0,
-            };
+    impl From<Gc<str>> for Gc<[u8]> {
+        /// Converts a garbage-collected string slice into a byte slice.
+        ///
+        /// # Example
+        ///
+        /// ```
+        /// # use dumpster::unsync::Gc;
+        /// let string: Gc<str> = Gc::from("eggplant");
+        /// let bytes: Gc<[u8]> = Gc::from(string);
+        /// assert_eq!("eggplant".as_bytes(), bytes.as_ref());
+        /// ```
+        #[inline]
+        fn from(value: Gc<str>) -> Self {
+            unsafe { Gc::from_ptr(Gc::into_ptr(value) as *const GcBox<[u8]>) }
+        }
+    }
 
-            for (i, item) in slice.iter().enumerate() {
-                ptr::write(elems.add(i), item.clone());
-                guard.n_elems += 1;
+    impl From<String> for Gc<str> {
+        /// Allocates a garbage-collected string slice and copies `v` into it.
+        ///
+        /// # Example
+        ///
+        /// ```
+        /// # use dumpster::unsync::Gc;
+        /// let original: String = "statue".to_owned();
+        /// let shared: Gc<str> = Gc::from(original);
+        /// assert_eq!("statue", &shared[..]);
+        /// ```
+        #[inline]
+        fn from(value: String) -> Self {
+            Self::from(&value[..])
+        }
+    }
+
+    impl<T: Trace> From<Box<T>> for Gc<T> {
+        /// Move a boxed object to a new, reference counted, allocation.
+        ///
+        /// # Example
+        ///
+        /// ```
+        /// # use std::rc::Rc;
+        /// let original: Box<i32> = Box::new(1);
+        /// let shared: Rc<i32> = Rc::from(original);
+        /// assert_eq!(1, *shared);
+        /// ```
+        #[inline]
+        fn from(src: Box<T>) -> Self {
+            unsafe {
+                let layout = Layout::for_value(&*src);
+                let gc_ptr = Gc::allocate_for_layout(layout, <*mut u8>::cast::<GcBox<T>>);
+
+                // Copy value as bytes
+                ptr::copy_nonoverlapping(
+                    (&raw const *src).cast::<u8>(),
+                    (&raw mut (*gc_ptr).value).cast::<u8>(),
+                    layout.size(),
+                );
+
+                // Free the allocation without dropping its contents
+                let bptr = Box::into_raw(src);
+                let src = Box::from_raw(bptr.cast::<mem::ManuallyDrop<T>>());
+                drop(src);
+
+                DUMPSTER.with(Dumpster::notify_created_gc);
+                Self::from_ptr(gc_ptr)
             }
+        }
+    }
 
-            // All clear. Forget the guard so it doesn't free the new GcBox.
-            mem::forget(guard);
+    impl<T: Trace> From<Vec<T>> for Gc<[T]> {
+        /// Allocates a garbage-collected slice and moves `vec`'s items into it.
+        ///
+        /// # Example
+        ///
+        /// ```
+        /// # use dumpster::unsync::Gc;
+        /// let unique: Vec<i32> = vec![1, 2, 3];
+        /// let shared: Gc<[i32]> = Gc::from(unique);
+        /// assert_eq!(&[1, 2, 3], &shared[..]);
+        /// ```
+        #[inline]
+        fn from(vec: Vec<T>) -> Self {
+            let mut vec = ManuallyDrop::new(vec);
+            let vec_cap = vec.capacity();
+            let vec_len = vec.len();
+            let vec_ptr = vec.as_mut_ptr();
 
-            DUMPSTER.with(Dumpster::notify_created_gc);
+            let gc_ptr = Self::allocate_for_slice(vec_len);
 
-            Self {
-                ptr: Cell::new(Nullable::from_ptr(ptr)),
+            unsafe {
+                let dst_ptr = (&raw mut (*gc_ptr).value).cast::<T>();
+                ptr::copy_nonoverlapping(vec_ptr, dst_ptr, vec_len);
+
+                let _ = Vec::from_raw_parts(vec_ptr, 0, vec_cap);
+
+                DUMPSTER.with(Dumpster::notify_created_gc);
+                Self::from_ptr(gc_ptr)
             }
         }
     }
-}
 
-impl<T: Trace + Clone> From<&mut [T]> for Gc<[T]> {
-    /// Allocates a garbage-collected slice and fills it by cloning `v`'s items.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use dumpster::unsync::Gc;
-    /// let mut original = [1, 2, 3];
-    /// let original: &mut [i32] = &mut original;
-    /// let shared: Gc<[i32]> = Gc::from(original);
-    /// assert_eq!(&[1, 2, 3], &shared[..]);
-    /// ```
-    #[inline]
-    fn from(value: &mut [T]) -> Self {
-        Gc::from(&*value)
-    }
-}
-
-impl From<&str> for Gc<str> {
-    /// Allocates a garbage-collected string slice and copies `v` into it.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use dumpster::unsync::Gc;
-    /// let shared: Gc<str> = Gc::from("statue");
-    /// assert_eq!("statue", &shared[..]);
-    /// ```
-    #[inline]
-    fn from(v: &str) -> Self {
-        let bytes = Gc::<[u8]>::from(v.as_bytes());
-        unsafe { Gc::from_ptr(Gc::into_ptr(bytes) as *const GcBox<str>) }
-    }
-}
-
-impl From<&mut str> for Gc<str> {
-    /// Allocates a garbage-collected string slice and copies `v` into it.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use dumpster::unsync::Gc;
-    /// let mut original = String::from("statue");
-    /// let original: &mut str = &mut original;
-    /// let shared: Gc<str> = Gc::from(original);
-    /// assert_eq!("statue", &shared[..]);
-    /// ```
-    #[inline]
-    fn from(v: &mut str) -> Self {
-        Gc::from(&*v)
-    }
-}
-
-impl From<Gc<str>> for Gc<[u8]> {
-    /// Converts a garbage-collected string slice into a byte slice.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use dumpster::unsync::Gc;
-    /// let string: Gc<str> = Gc::from("eggplant");
-    /// let bytes: Gc<[u8]> = Gc::from(string);
-    /// assert_eq!("eggplant".as_bytes(), bytes.as_ref());
-    /// ```
-    #[inline]
-    fn from(value: Gc<str>) -> Self {
-        unsafe { Gc::from_ptr(Gc::into_ptr(value) as *const GcBox<[u8]>) }
-    }
-}
-
-impl From<String> for Gc<str> {
-    /// Allocates a garbage-collected string slice and copies `v` into it.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use dumpster::unsync::Gc;
-    /// let original: String = "statue".to_owned();
-    /// let shared: Gc<str> = Gc::from(original);
-    /// assert_eq!("statue", &shared[..]);
-    /// ```
-    #[inline]
-    fn from(value: String) -> Self {
-        Self::from(&value[..])
-    }
-}
-
-impl<T: Trace> From<Box<T>> for Gc<T> {
-    /// Move a boxed object to a new, reference counted, allocation.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use std::rc::Rc;
-    /// let original: Box<i32> = Box::new(1);
-    /// let shared: Rc<i32> = Rc::from(original);
-    /// assert_eq!(1, *shared);
-    /// ```
-    #[inline]
-    fn from(src: Box<T>) -> Self {
-        unsafe {
-            let layout = Layout::for_value(&*src);
-            let gc_ptr = Gc::allocate_for_layout(layout, <*mut u8>::cast::<GcBox<T>>);
-
-            // Copy value as bytes
-            ptr::copy_nonoverlapping(
-                (&raw const *src).cast::<u8>(),
-                (&raw mut (*gc_ptr).value).cast::<u8>(),
-                layout.size(),
-            );
-
-            // Free the allocation without dropping its contents
-            let bptr = Box::into_raw(src);
-            let src = Box::from_raw(bptr.cast::<mem::ManuallyDrop<T>>());
-            drop(src);
-
-            DUMPSTER.with(Dumpster::notify_created_gc);
-            Self::from_ptr(gc_ptr)
-        }
-    }
-}
-
-impl<T: Trace> From<Vec<T>> for Gc<[T]> {
-    /// Allocates a garbage-collected slice and moves `vec`'s items into it.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use dumpster::unsync::Gc;
-    /// let unique: Vec<i32> = vec![1, 2, 3];
-    /// let shared: Gc<[i32]> = Gc::from(unique);
-    /// assert_eq!(&[1, 2, 3], &shared[..]);
-    /// ```
-    #[inline]
-    fn from(vec: Vec<T>) -> Self {
-        let mut vec = ManuallyDrop::new(vec);
-        let vec_cap = vec.capacity();
-        let vec_len = vec.len();
-        let vec_ptr = vec.as_mut_ptr();
-
-        let gc_ptr = Self::allocate_for_slice(vec_len);
-
-        unsafe {
-            let dst_ptr = (&raw mut (*gc_ptr).value).cast::<T>();
-            ptr::copy_nonoverlapping(vec_ptr, dst_ptr, vec_len);
-
-            let _ = Vec::from_raw_parts(vec_ptr, 0, vec_cap);
-
-            DUMPSTER.with(Dumpster::notify_created_gc);
-            Self::from_ptr(gc_ptr)
-        }
-    }
-}
-
-impl<'a, B: Trace> From<Cow<'a, B>> for Gc<B>
-where
-    B: ToOwned + ?Sized,
-    Gc<B>: From<&'a B> + From<B::Owned>,
-{
-    /// Creates a reference-counted pointer from a clone-on-write pointer by
-    /// copying its content.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// # use dumpster::unsync::Gc;
-    /// # use std::borrow::Cow;
-    /// let cow: Cow<'_, str> = Cow::Borrowed("eggplant");
-    /// let shared: Gc<str> = Gc::from(cow);
-    /// assert_eq!("eggplant", &shared[..]);
-    /// ```
-    #[inline]
-    fn from(cow: Cow<'a, B>) -> Gc<B> {
-        match cow {
-            Cow::Borrowed(s) => Gc::from(s),
-            Cow::Owned(s) => Gc::from(s),
+    impl<'a, B: Trace> From<Cow<'a, B>> for Gc<B>
+    where
+        B: ToOwned + ?Sized,
+        Gc<B>: From<&'a B> + From<B::Owned>,
+    {
+        /// Creates a reference-counted pointer from a clone-on-write pointer by
+        /// copying its content.
+        ///
+        /// # Example
+        ///
+        /// ```rust
+        /// # use dumpster::unsync::Gc;
+        /// # use std::borrow::Cow;
+        /// let cow: Cow<'_, str> = Cow::Borrowed("eggplant");
+        /// let shared: Gc<str> = Gc::from(cow);
+        /// assert_eq!("eggplant", &shared[..]);
+        /// ```
+        #[inline]
+        fn from(cow: Cow<'a, B>) -> Gc<B> {
+            match cow {
+                Cow::Borrowed(s) => Gc::from(s),
+                Cow::Owned(s) => Gc::from(s),
+            }
         }
     }
 }

--- a/dumpster/src/unsync/tests.rs
+++ b/dumpster/src/unsync/tests.rs
@@ -307,3 +307,42 @@ fn escape_dead_pointer() {
         ESCAPED.with(|e| e.lock().unwrap().as_ref().unwrap().x)
     );
 }
+
+#[test]
+fn from_box() {
+    let gc: Gc<String> = Gc::from(Box::new(String::from("hello")));
+
+    // The `From<Box<T>>` implementation executes a different code path to
+    // construct the `Gc`.
+    //
+    // Here we ensure that the metadata is initialized to a valid state.
+    assert_eq!(gc.ref_count().get(), 1);
+
+    assert_eq!(&*gc, "hello");
+}
+
+#[test]
+fn from_slice() {
+    let gc: Gc<[String]> = Gc::from(&[String::from("hello"), String::from("world")][..]);
+
+    // The `From<&[T]>` implementation executes a different code path to
+    // construct the `Gc`.
+    //
+    // Here we ensure that the metadata is initialized to a valid state.
+    assert_eq!(gc.ref_count().get(), 1);
+
+    assert_eq!(&*gc, ["hello", "world"]);
+}
+
+#[test]
+fn from_vec() {
+    let gc: Gc<[String]> = Gc::from(vec![String::from("hello"), String::from("world")]);
+
+    // The `From<Vec<T>>` implementation executes a different code path to
+    // construct the `Gc`.
+    //
+    // Here we ensure that the metadata is initialized to a valid state.
+    assert_eq!(gc.ref_count().get(), 1);
+
+    assert_eq!(&*gc, ["hello", "world"]);
+}


### PR DESCRIPTION
This PR adds all the `From` impls that `Rc` and `Arc` have that are possible to be implemented without nightly features.

This PR adds the following `From` impls to both `Gc`s:
- `From<T> for Gc<T>`
- `From<[T;N]> for Gc<[T]>`
- `From<&(mut) [T]> for Gc<[T]>`
- `From<&(mut) str> for Gc<[T]>`
- `From<Box<T: Sized>> for Gc<T>`
- `From<Gc<str>> for Gc<[u8]>`
- `From<String> for Gc<str>`
- `From<Vec<T>> for Gc<[T]>`

The following `From` impls were intentionally left out because they require nightly features:
- requires `ptr_metadata`:
  - `From<&(mut) CStr> for Gc<CStr>`
  - `From<&(mut) OsStr> for Gc<OsStr>`
  - `From<&(mut) Path> for Gc<Path>`
  - `From<Box<CString>> for Gc<CStr>`
  - `From<Box<OsString>> for Gc<OsStr>`
  - `From<Box<PathBuf>> for Gc<Path>`
  - `From<Box<T: ?Sized>> for Gc<T>`
- a type/trait involved is unstable:
  - `From<Gc<ByteStr>> for Gc<[u8]>`
  - `From<Gc<W: LocalWake>> for LocalWaker`
  - `From<Gc<W: LocalWake>> for RawWaker`
  - `From<Gc<[u8]>> for Gc<ByteStr>`

The code for these implementations is derived from the code in the standard library. I'm not sure if or how I should add attribution. Please let me know.