### PR TITLE
Add `Gc::make_mut`

### DIFF
--- a/dumpster/src/lib.rs
+++ b/dumpster/src/lib.rs
@@ -358,3 +358,13 @@ fn contains_gcs<T: Trace + ?Sized>(x: &T) -> Result<bool, ()> {
     x.accept(&mut visit)?;
     Ok(visit.0)
 }
+
+/// Panics with a message that explains that the gc object has already been collected.
+#[cold]
+#[inline(never)]
+fn panic_deref_of_collected_object() -> ! {
+    panic!(
+        "Attempt to dereference Gc to already-collected object. \
+    This means a Gc escaped from a Drop implementation, likely implying a bug in your code.",
+    );
+}

--- a/dumpster/src/ptr.rs
+++ b/dumpster/src/ptr.rs
@@ -129,6 +129,15 @@ impl<T: ?Sized> Nullable<T> {
     pub fn unwrap(self) -> NonNull<T> {
         self.as_option().unwrap()
     }
+
+    /// Convert this pointer to a `NonNull<T>`.
+    ///
+    /// # Safety
+    ///
+    /// The pointer must not be null.
+    pub unsafe fn unwrap_unchecked(self) -> NonNull<T> {
+        self.as_option().unwrap_unchecked()
+    }
 }
 
 impl<T: ?Sized> Clone for Nullable<T> {

--- a/dumpster/src/sync/mod.rs
+++ b/dumpster/src/sync/mod.rs
@@ -536,7 +536,9 @@ impl<T: Trace + Send + Sync + Clone> Gc<T> {
         }
 
         // SAFETY: we have exclusive access to this `GcBox` because we ensured
-        // that we hold the only reference to this allocation
+        // that we hold the only reference to this allocation.
+        // No other `Gc`s point to this allocation because the strong count is 1, and there are no
+        // loose pointers internal to the collector because the weak count is 0.
         unsafe { &mut (*this.ptr.get_mut().as_ptr()).value }
     }
 }

--- a/dumpster/src/sync/tests.rs
+++ b/dumpster/src/sync/tests.rs
@@ -743,3 +743,86 @@ fn from_vec() {
 
     assert_eq!(&*gc, ["hello", "world"]);
 }
+
+#[test]
+fn make_mut() {
+    let mut a = Gc::new(42);
+    let mut b = a.clone();
+    let mut c = b.clone();
+
+    assert_eq!(*Gc::make_mut(&mut a), 42);
+    assert_eq!(*Gc::make_mut(&mut b), 42);
+    assert_eq!(*Gc::make_mut(&mut c), 42);
+
+    *Gc::make_mut(&mut a) += 1;
+    *Gc::make_mut(&mut b) += 2;
+    *Gc::make_mut(&mut c) += 3;
+
+    assert_eq!(*a, 43);
+    assert_eq!(*b, 44);
+    assert_eq!(*c, 45);
+
+    // they should all be unique
+    assert_eq!(Gc::ref_count(&a).get(), 1);
+    assert_eq!(Gc::ref_count(&b).get(), 1);
+    assert_eq!(Gc::ref_count(&c).get(), 1);
+}
+
+#[test]
+fn make_mut_2() {
+    let mut a = Gc::new(42);
+    let b = a.clone();
+    let c = b.clone();
+
+    assert_eq!(*a, 42);
+    assert_eq!(*b, 42);
+    assert_eq!(*c, 42);
+
+    *Gc::make_mut(&mut a) += 1;
+
+    assert_eq!(*a, 43);
+    assert_eq!(*b, 42);
+    assert_eq!(*c, 42);
+
+    // a should be unique
+    // b and c should share their object
+    assert_eq!(Gc::ref_count(&a).get(), 1);
+    assert_eq!(Gc::ref_count(&b).get(), 2);
+    assert_eq!(Gc::ref_count(&c).get(), 2);
+}
+
+#[test]
+fn make_mut_of_object_in_dumpster() {
+    #[derive(Clone)]
+    struct Foo {
+        // just some gc pointer so foo lands in the dumpster
+        something: Gc<i32>,
+    }
+
+    unsafe impl Trace for Foo {
+        fn accept<V: Visitor>(&self, visitor: &mut V) -> Result<(), ()> {
+            self.something.accept(visitor)
+        }
+    }
+
+    let mut foo = Gc::new(Foo {
+        something: Gc::new(5),
+    });
+
+    drop(foo.clone());
+
+    // now foo is in the dumpster
+    // and its ref count is one
+    assert_eq!(foo.ref_count().get(), 1);
+
+    // we get a mut reference
+    let foo_mut = Gc::make_mut(&mut foo);
+
+    // now we collect garbage while we're also holding onto a mutable reference to foo
+    // if foo is still in the dumpster then the collection will dereference it and cause UB
+    collect();
+
+    // we need to do something with `foo_mut` here so the mutable borrow is actually held
+    // during collection
+    assert_eq!(*foo_mut.something, 5);
+}

--- a/dumpster/src/unsync/mod.rs
+++ b/dumpster/src/unsync/mod.rs
@@ -506,8 +506,9 @@ impl<T: Trace + Clone> Gc<T> {
             *this = Gc::new(box_ref.value.clone());
         }
 
-        // SAFETY: we have exclusive access to this `GcBox`
-        // because we ensured that the ref count is 1
+        // SAFETY: we have exclusive access to this `GcBox` because we ensured
+        // that the ref count is 1 and that there are no loose pointers in the
+        // `to_collect` buffer of this thread's dumpster.
         unsafe { &mut (*this.ptr.get_mut().as_ptr()).value }
     }
 }


### PR DESCRIPTION
This only supports `Sized` types as `?Sized` types would require the nightly feature `clone_to_uninit`.