### PR TITLE
Manually import instead of by wildcard

### DIFF
--- a/dumpster/src/sync/mod.rs
+++ b/dumpster/src/sync/mod.rs
@@ -862,7 +862,10 @@ impl<T: Trace + Send + Sync + ?Sized> Debug for Gc<T> {
 /// The original implementation was published under both the [MIT](https://mit-license.org/) and [Apache license](http://www.apache.org/licenses/LICENSE-2.0), version 2.0.
 /// Copies of the licenses are available at the linked addresses.
 mod from {
-    use super::*;
+    use super::{
+        dealloc, mem, notify_created_gc, ptr, slice, AtomicUsize, Cow, Gc, GcBox, Layout,
+        ManuallyDrop, Nullable, Trace, UnsafeCell,
+    };
 
     impl<T: Trace + Send + Sync> From<T> for Gc<T> {
         /// Converts a generic type `T` into an `Gc<T>`

--- a/dumpster/src/unsync/mod.rs
+++ b/dumpster/src/unsync/mod.rs
@@ -816,7 +816,10 @@ where
 /// The original implementation was published under both the [MIT](https://mit-license.org/) and [Apache license](http://www.apache.org/licenses/LICENSE-2.0), version 2.0.
 /// Copies of the licenses are available at the linked addresses.
 mod from {
-    use super::*;
+    use super::{
+        dealloc, mem, ptr, slice, Cell, Cow, Dumpster, Gc, GcBox, Layout, ManuallyDrop, Nullable,
+        Trace, DUMPSTER,
+    };
 
     impl<T: Trace> From<T> for Gc<T> {
         /// Converts a generic type `T` into an `Gc<T>`


### PR DESCRIPTION
Clippy warns about it. I tried to suppress the warning with `expect`, but that then just then warns about `unfulfilled_lint_expectations` (??). Sounds like a clippy bug...