### PR TITLE
Change `std` attribution to be project wide

### DIFF
--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -1,0 +1,176 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,0 +1,25 @@
+Copyright (c) The Rust Project Contributors
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -124,3 +124,7 @@ dumpster = { version = "1.1.1", features = ["coerce-unsized"]}
 
 This code is licensed under the Mozilla Public License, version 2.0.
 For more information, refer to [LICENSE.md](LICENSE.md).
+
+This project includes portions of code derived from the Rust standard library,
+which is dual-licensed under the MIT and Apache 2.0 licenses.
+Copyright (c) The Rust Project Developers.

--- a/dumpster/src/sync/mod.rs
+++ b/dumpster/src/sync/mod.rs
@@ -933,311 +933,301 @@ impl<T: Trace + Send + Sync + ?Sized> Debug for Gc<T> {
     }
 }
 
-/// The code in the below module is derived from the implementations for [`std::sync::Arc`] found in the [Rust standard library](https://github.com/rust-lang/rust).
-/// The original implementation was published under both the [MIT](https://mit-license.org/) and [Apache license](http://www.apache.org/licenses/LICENSE-2.0), version 2.0.
-/// Copies of the licenses are available at the linked addresses.
-mod from {
-    use super::{
-        dealloc, mem, notify_created_gc, ptr, slice, AtomicUsize, Cow, Gc, GcBox, Layout,
-        ManuallyDrop, Nullable, Trace, UnsafeCell,
-    };
-
-    impl<T: Trace + Send + Sync> From<T> for Gc<T> {
-        /// Converts a generic type `T` into an `Gc<T>`
-        ///
-        /// The conversion allocates on the heap and moves `t`
-        /// from the stack into it.
-        ///
-        /// # Example
-        /// ```rust
-        /// # use dumpster::unsync::Gc;
-        /// let x = 5;
-        /// let rc = Gc::new(5);
-        ///
-        /// assert_eq!(Gc::from(x), rc);
-        /// ```
-        fn from(value: T) -> Self {
-            Gc::new(value)
-        }
+impl<T: Trace + Send + Sync> From<T> for Gc<T> {
+    /// Converts a generic type `T` into an `Gc<T>`
+    ///
+    /// The conversion allocates on the heap and moves `t`
+    /// from the stack into it.
+    ///
+    /// # Example
+    /// ```rust
+    /// # use dumpster::unsync::Gc;
+    /// let x = 5;
+    /// let rc = Gc::new(5);
+    ///
+    /// assert_eq!(Gc::from(x), rc);
+    /// ```
+    fn from(value: T) -> Self {
+        Gc::new(value)
     }
+}
 
-    impl<T: Trace + Send + Sync, const N: usize> From<[T; N]> for Gc<[T]> {
-        /// Converts a [`[T; N]`](prim@array) into an `Gc<[T]>`.
-        ///
-        /// The conversion moves the array into a newly allocated `Gc`.
-        ///
-        /// # Example
-        ///
-        /// ```
-        /// # use dumpster::unsync::Gc;
-        /// let original: [i32; 3] = [1, 2, 3];
-        /// let shared: Gc<[i32]> = Gc::from(original);
-        /// assert_eq!(&[1, 2, 3], &shared[..]);
-        /// ```
-        #[inline]
-        fn from(v: [T; N]) -> Gc<[T]> {
-            sync_coerce_gc!(Gc::<[T; N]>::from(v))
-        }
+impl<T: Trace + Send + Sync, const N: usize> From<[T; N]> for Gc<[T]> {
+    /// Converts a [`[T; N]`](prim@array) into an `Gc<[T]>`.
+    ///
+    /// The conversion moves the array into a newly allocated `Gc`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use dumpster::unsync::Gc;
+    /// let original: [i32; 3] = [1, 2, 3];
+    /// let shared: Gc<[i32]> = Gc::from(original);
+    /// assert_eq!(&[1, 2, 3], &shared[..]);
+    /// ```
+    #[inline]
+    fn from(v: [T; N]) -> Gc<[T]> {
+        sync_coerce_gc!(Gc::<[T; N]>::from(v))
     }
+}
 
-    impl<T: Trace + Send + Sync + Clone> From<&[T]> for Gc<[T]> {
-        /// Allocates a garbage-collected slice and fills it by cloning `slice`'s items.
-        ///
-        /// # Example
-        ///
-        /// ```
-        /// # use dumpster::unsync::Gc;
-        /// let original: &[i32] = &[1, 2, 3];
-        /// let shared: Gc<[i32]> = Gc::from(original);
-        /// assert_eq!(&[1, 2, 3], &shared[..]);
-        /// ```
-        #[inline]
-        fn from(slice: &[T]) -> Gc<[T]> {
-            // Panic guard while cloning T elements.
-            // In the event of a panic, elements that have been written
-            // into the new GcBox will be dropped, then the memory freed.
-            struct Guard<T> {
-                /// pointer to `GcBox` to deallocate on panic
-                mem: *mut u8,
-                /// layout of the `GcBox` to deallocate on panic
-                layout: Layout,
-                /// pointer to the `GcBox`'s value
-                elems: *mut T,
-                /// the number of elements cloned so far
-                n_elems: usize,
-            }
+impl<T: Trace + Send + Sync + Clone> From<&[T]> for Gc<[T]> {
+    /// Allocates a garbage-collected slice and fills it by cloning `slice`'s items.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use dumpster::unsync::Gc;
+    /// let original: &[i32] = &[1, 2, 3];
+    /// let shared: Gc<[i32]> = Gc::from(original);
+    /// assert_eq!(&[1, 2, 3], &shared[..]);
+    /// ```
+    #[inline]
+    fn from(slice: &[T]) -> Gc<[T]> {
+        // Panic guard while cloning T elements.
+        // In the event of a panic, elements that have been written
+        // into the new GcBox will be dropped, then the memory freed.
+        struct Guard<T> {
+            /// pointer to `GcBox` to deallocate on panic
+            mem: *mut u8,
+            /// layout of the `GcBox` to deallocate on panic
+            layout: Layout,
+            /// pointer to the `GcBox`'s value
+            elems: *mut T,
+            /// the number of elements cloned so far
+            n_elems: usize,
+        }
 
-            impl<T> Drop for Guard<T> {
-                fn drop(&mut self) {
-                    unsafe {
-                        let slice = slice::from_raw_parts_mut(self.elems, self.n_elems);
-                        ptr::drop_in_place(slice);
+        impl<T> Drop for Guard<T> {
+            fn drop(&mut self) {
+                unsafe {
+                    let slice = slice::from_raw_parts_mut(self.elems, self.n_elems);
+                    ptr::drop_in_place(slice);
 
-                        dealloc(self.mem, self.layout);
-                    }
-                }
-            }
-
-            unsafe {
-                let value_layout = Layout::array::<T>(slice.len()).unwrap();
-
-                let layout = Layout::new::<GcBox<()>>()
-                    .extend(value_layout)
-                    .unwrap()
-                    .0
-                    .pad_to_align();
-
-                let ptr = Self::allocate_for_layout_of_box(layout, |mem| {
-                    ptr::slice_from_raw_parts_mut(mem.cast::<T>(), slice.len()) as *mut GcBox<[T]>
-                });
-
-                // Pointer to first element
-                let elems = (&raw mut (*ptr).value).cast::<T>();
-
-                let mut guard = Guard {
-                    mem: ptr.cast::<u8>(),
-                    layout,
-                    elems,
-                    n_elems: 0,
-                };
-
-                for (i, item) in slice.iter().enumerate() {
-                    ptr::write(elems.add(i), item.clone());
-                    guard.n_elems += 1;
-                }
-
-                // All clear. Forget the guard so it doesn't free the new GcBox.
-                mem::forget(guard);
-
-                notify_created_gc();
-
-                Self {
-                    ptr: UnsafeCell::new(Nullable::from_ptr(ptr)),
-                    tag: AtomicUsize::new(0),
+                    dealloc(self.mem, self.layout);
                 }
             }
         }
-    }
 
-    impl<T: Trace + Send + Sync + Clone> From<&mut [T]> for Gc<[T]> {
-        /// Allocates a garbage-collected slice and fills it by cloning `v`'s items.
-        ///
-        /// # Example
-        ///
-        /// ```
-        /// # use dumpster::unsync::Gc;
-        /// let mut original = [1, 2, 3];
-        /// let original: &mut [i32] = &mut original;
-        /// let shared: Gc<[i32]> = Gc::from(original);
-        /// assert_eq!(&[1, 2, 3], &shared[..]);
-        /// ```
-        #[inline]
-        fn from(value: &mut [T]) -> Self {
-            Gc::from(&*value)
-        }
-    }
+        unsafe {
+            let value_layout = Layout::array::<T>(slice.len()).unwrap();
 
-    impl From<&str> for Gc<str> {
-        /// Allocates a garbage-collected string slice and copies `v` into it.
-        ///
-        /// # Example
-        ///
-        /// ```
-        /// # use dumpster::unsync::Gc;
-        /// let shared: Gc<str> = Gc::from("statue");
-        /// assert_eq!("statue", &shared[..]);
-        /// ```
-        #[inline]
-        fn from(v: &str) -> Self {
-            let bytes = Gc::<[u8]>::from(v.as_bytes());
-            let (ptr, tag) = Gc::into_ptr(bytes);
-            unsafe { Gc::from_ptr(ptr as *const GcBox<str>, tag) }
-        }
-    }
+            let layout = Layout::new::<GcBox<()>>()
+                .extend(value_layout)
+                .unwrap()
+                .0
+                .pad_to_align();
 
-    impl From<&mut str> for Gc<str> {
-        /// Allocates a garbage-collected string slice and copies `v` into it.
-        ///
-        /// # Example
-        ///
-        /// ```
-        /// # use dumpster::unsync::Gc;
-        /// let mut original = String::from("statue");
-        /// let original: &mut str = &mut original;
-        /// let shared: Gc<str> = Gc::from(original);
-        /// assert_eq!("statue", &shared[..]);
-        /// ```
-        #[inline]
-        fn from(v: &mut str) -> Self {
-            Gc::from(&*v)
-        }
-    }
+            let ptr = Self::allocate_for_layout_of_box(layout, |mem| {
+                ptr::slice_from_raw_parts_mut(mem.cast::<T>(), slice.len()) as *mut GcBox<[T]>
+            });
 
-    impl From<Gc<str>> for Gc<[u8]> {
-        /// Converts a garbage-collected string slice into a byte slice.
-        ///
-        /// # Example
-        ///
-        /// ```
-        /// # use dumpster::unsync::Gc;
-        /// let string: Gc<str> = Gc::from("eggplant");
-        /// let bytes: Gc<[u8]> = Gc::from(string);
-        /// assert_eq!("eggplant".as_bytes(), bytes.as_ref());
-        /// ```
-        #[inline]
-        fn from(value: Gc<str>) -> Self {
-            let (ptr, tag) = Gc::into_ptr(value);
-            unsafe { Gc::from_ptr(ptr as *const GcBox<[u8]>, tag) }
-        }
-    }
+            // Pointer to first element
+            let elems = (&raw mut (*ptr).value).cast::<T>();
 
-    impl From<String> for Gc<str> {
-        /// Allocates a garbage-collected string slice and copies `v` into it.
-        ///
-        /// # Example
-        ///
-        /// ```
-        /// # use dumpster::unsync::Gc;
-        /// let original: String = "statue".to_owned();
-        /// let shared: Gc<str> = Gc::from(original);
-        /// assert_eq!("statue", &shared[..]);
-        /// ```
-        #[inline]
-        fn from(value: String) -> Self {
-            Self::from(&value[..])
-        }
-    }
+            let mut guard = Guard {
+                mem: ptr.cast::<u8>(),
+                layout,
+                elems,
+                n_elems: 0,
+            };
 
-    impl<T: Trace + Send + Sync> From<Box<T>> for Gc<T> {
-        /// Move a boxed object to a new, garbage collected, allocation.
-        ///
-        /// # Example
-        ///
-        /// ```
-        /// # use dumpster::sync::Gc;
-        /// let original: Box<i32> = Box::new(1);
-        /// let shared: Gc<i32> = Gc::from(original);
-        /// assert_eq!(1, *shared);
-        /// ```
-        #[inline]
-        fn from(src: Box<T>) -> Self {
-            unsafe {
-                let layout = Layout::for_value(&*src);
-                let gc_ptr = Gc::allocate_for_layout(layout, <*mut u8>::cast::<GcBox<T>>);
+            for (i, item) in slice.iter().enumerate() {
+                ptr::write(elems.add(i), item.clone());
+                guard.n_elems += 1;
+            }
 
-                // Copy value as bytes
-                ptr::copy_nonoverlapping(
-                    (&raw const *src).cast::<u8>(),
-                    (&raw mut (*gc_ptr).value).cast::<u8>(),
-                    layout.size(),
-                );
+            // All clear. Forget the guard so it doesn't free the new GcBox.
+            mem::forget(guard);
 
-                // Free the allocation without dropping its contents
-                let bptr = Box::into_raw(src);
-                let src = Box::from_raw(bptr.cast::<mem::ManuallyDrop<T>>());
-                drop(src);
+            notify_created_gc();
 
-                notify_created_gc();
-                Self::from_ptr(gc_ptr, 0)
+            Self {
+                ptr: UnsafeCell::new(Nullable::from_ptr(ptr)),
+                tag: AtomicUsize::new(0),
             }
         }
     }
+}
 
-    impl<T: Trace + Send + Sync> From<Vec<T>> for Gc<[T]> {
-        /// Allocates a garbage-collected slice and moves `vec`'s items into it.
-        ///
-        /// # Example
-        ///
-        /// ```
-        /// # use dumpster::unsync::Gc;
-        /// let unique: Vec<i32> = vec![1, 2, 3];
-        /// let shared: Gc<[i32]> = Gc::from(unique);
-        /// assert_eq!(&[1, 2, 3], &shared[..]);
-        /// ```
-        #[inline]
-        fn from(vec: Vec<T>) -> Self {
-            let mut vec = ManuallyDrop::new(vec);
-            let vec_cap = vec.capacity();
-            let vec_len = vec.len();
-            let vec_ptr = vec.as_mut_ptr();
+impl<T: Trace + Send + Sync + Clone> From<&mut [T]> for Gc<[T]> {
+    /// Allocates a garbage-collected slice and fills it by cloning `v`'s items.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use dumpster::unsync::Gc;
+    /// let mut original = [1, 2, 3];
+    /// let original: &mut [i32] = &mut original;
+    /// let shared: Gc<[i32]> = Gc::from(original);
+    /// assert_eq!(&[1, 2, 3], &shared[..]);
+    /// ```
+    #[inline]
+    fn from(value: &mut [T]) -> Self {
+        Gc::from(&*value)
+    }
+}
 
-            let gc_ptr = Self::allocate_for_slice(vec_len);
+impl From<&str> for Gc<str> {
+    /// Allocates a garbage-collected string slice and copies `v` into it.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use dumpster::unsync::Gc;
+    /// let shared: Gc<str> = Gc::from("statue");
+    /// assert_eq!("statue", &shared[..]);
+    /// ```
+    #[inline]
+    fn from(v: &str) -> Self {
+        let bytes = Gc::<[u8]>::from(v.as_bytes());
+        let (ptr, tag) = Gc::into_ptr(bytes);
+        unsafe { Gc::from_ptr(ptr as *const GcBox<str>, tag) }
+    }
+}
 
-            unsafe {
-                let dst_ptr = (&raw mut (*gc_ptr).value).cast::<T>();
-                ptr::copy_nonoverlapping(vec_ptr, dst_ptr, vec_len);
+impl From<&mut str> for Gc<str> {
+    /// Allocates a garbage-collected string slice and copies `v` into it.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use dumpster::unsync::Gc;
+    /// let mut original = String::from("statue");
+    /// let original: &mut str = &mut original;
+    /// let shared: Gc<str> = Gc::from(original);
+    /// assert_eq!("statue", &shared[..]);
+    /// ```
+    #[inline]
+    fn from(v: &mut str) -> Self {
+        Gc::from(&*v)
+    }
+}
 
-                let _ = Vec::from_raw_parts(vec_ptr, 0, vec_cap);
+impl From<Gc<str>> for Gc<[u8]> {
+    /// Converts a garbage-collected string slice into a byte slice.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use dumpster::unsync::Gc;
+    /// let string: Gc<str> = Gc::from("eggplant");
+    /// let bytes: Gc<[u8]> = Gc::from(string);
+    /// assert_eq!("eggplant".as_bytes(), bytes.as_ref());
+    /// ```
+    #[inline]
+    fn from(value: Gc<str>) -> Self {
+        let (ptr, tag) = Gc::into_ptr(value);
+        unsafe { Gc::from_ptr(ptr as *const GcBox<[u8]>, tag) }
+    }
+}
 
-                notify_created_gc();
-                Self::from_ptr(gc_ptr, 0)
-            }
+impl From<String> for Gc<str> {
+    /// Allocates a garbage-collected string slice and copies `v` into it.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use dumpster::unsync::Gc;
+    /// let original: String = "statue".to_owned();
+    /// let shared: Gc<str> = Gc::from(original);
+    /// assert_eq!("statue", &shared[..]);
+    /// ```
+    #[inline]
+    fn from(value: String) -> Self {
+        Self::from(&value[..])
+    }
+}
+
+impl<T: Trace + Send + Sync> From<Box<T>> for Gc<T> {
+    /// Move a boxed object to a new, garbage collected, allocation.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use dumpster::sync::Gc;
+    /// let original: Box<i32> = Box::new(1);
+    /// let shared: Gc<i32> = Gc::from(original);
+    /// assert_eq!(1, *shared);
+    /// ```
+    #[inline]
+    fn from(src: Box<T>) -> Self {
+        unsafe {
+            let layout = Layout::for_value(&*src);
+            let gc_ptr = Gc::allocate_for_layout(layout, <*mut u8>::cast::<GcBox<T>>);
+
+            // Copy value as bytes
+            ptr::copy_nonoverlapping(
+                (&raw const *src).cast::<u8>(),
+                (&raw mut (*gc_ptr).value).cast::<u8>(),
+                layout.size(),
+            );
+
+            // Free the allocation without dropping its contents
+            let bptr = Box::into_raw(src);
+            let src = Box::from_raw(bptr.cast::<mem::ManuallyDrop<T>>());
+            drop(src);
+
+            notify_created_gc();
+            Self::from_ptr(gc_ptr, 0)
         }
     }
+}
 
-    impl<'a, B: Trace + Send + Sync> From<Cow<'a, B>> for Gc<B>
-    where
-        B: ToOwned + ?Sized,
-        Gc<B>: From<&'a B> + From<B::Owned>,
-    {
-        /// Creates a garbage-collected pointer from a clone-on-write pointer by
-        /// copying its content.
-        ///
-        /// # Example
-        ///
-        /// ```rust
-        /// # use dumpster::unsync::Gc;
-        /// # use std::borrow::Cow;
-        /// let cow: Cow<'_, str> = Cow::Borrowed("eggplant");
-        /// let shared: Gc<str> = Gc::from(cow);
-        /// assert_eq!("eggplant", &shared[..]);
-        /// ```
-        #[inline]
-        fn from(cow: Cow<'a, B>) -> Gc<B> {
-            match cow {
-                Cow::Borrowed(s) => Gc::from(s),
-                Cow::Owned(s) => Gc::from(s),
-            }
+impl<T: Trace + Send + Sync> From<Vec<T>> for Gc<[T]> {
+    /// Allocates a garbage-collected slice and moves `vec`'s items into it.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use dumpster::unsync::Gc;
+    /// let unique: Vec<i32> = vec![1, 2, 3];
+    /// let shared: Gc<[i32]> = Gc::from(unique);
+    /// assert_eq!(&[1, 2, 3], &shared[..]);
+    /// ```
+    #[inline]
+    fn from(vec: Vec<T>) -> Self {
+        let mut vec = ManuallyDrop::new(vec);
+        let vec_cap = vec.capacity();
+        let vec_len = vec.len();
+        let vec_ptr = vec.as_mut_ptr();
+
+        let gc_ptr = Self::allocate_for_slice(vec_len);
+
+        unsafe {
+            let dst_ptr = (&raw mut (*gc_ptr).value).cast::<T>();
+            ptr::copy_nonoverlapping(vec_ptr, dst_ptr, vec_len);
+
+            let _ = Vec::from_raw_parts(vec_ptr, 0, vec_cap);
+
+            notify_created_gc();
+            Self::from_ptr(gc_ptr, 0)
+        }
+    }
+}
+
+impl<'a, B: Trace + Send + Sync> From<Cow<'a, B>> for Gc<B>
+where
+    B: ToOwned + ?Sized,
+    Gc<B>: From<&'a B> + From<B::Owned>,
+{
+    /// Creates a garbage-collected pointer from a clone-on-write pointer by
+    /// copying its content.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use dumpster::unsync::Gc;
+    /// # use std::borrow::Cow;
+    /// let cow: Cow<'_, str> = Cow::Borrowed("eggplant");
+    /// let shared: Gc<str> = Gc::from(cow);
+    /// assert_eq!("eggplant", &shared[..]);
+    /// ```
+    #[inline]
+    fn from(cow: Cow<'a, B>) -> Gc<B> {
+        match cow {
+            Cow::Borrowed(s) => Gc::from(s),
+            Cow::Owned(s) => Gc::from(s),
         }
     }
 }

--- a/dumpster/src/unsync/mod.rs
+++ b/dumpster/src/unsync/mod.rs
@@ -883,308 +883,298 @@ where
 {
 }
 
-/// The code in the below module is derived from the implementations for [`std::rc::Rc`] found in the [Rust standard library](https://github.com/rust-lang/rust).
-/// The original implementation was published under both the [MIT](https://mit-license.org/) and [Apache license](http://www.apache.org/licenses/LICENSE-2.0), version 2.0.
-/// Copies of the licenses are available at the linked addresses.
-mod from {
-    use super::{
-        dealloc, mem, ptr, slice, Cell, Cow, Dumpster, Gc, GcBox, Layout, ManuallyDrop, Nullable,
-        Trace, DUMPSTER,
-    };
-
-    impl<T: Trace> From<T> for Gc<T> {
-        /// Converts a generic type `T` into an `Gc<T>`
-        ///
-        /// The conversion allocates on the heap and moves `t`
-        /// from the stack into it.
-        ///
-        /// # Example
-        /// ```rust
-        /// # use dumpster::unsync::Gc;
-        /// let x = 5;
-        /// let rc = Gc::new(5);
-        ///
-        /// assert_eq!(Gc::from(x), rc);
-        /// ```
-        fn from(value: T) -> Self {
-            Gc::new(value)
-        }
+impl<T: Trace> From<T> for Gc<T> {
+    /// Converts a generic type `T` into an `Gc<T>`
+    ///
+    /// The conversion allocates on the heap and moves `t`
+    /// from the stack into it.
+    ///
+    /// # Example
+    /// ```rust
+    /// # use dumpster::unsync::Gc;
+    /// let x = 5;
+    /// let rc = Gc::new(5);
+    ///
+    /// assert_eq!(Gc::from(x), rc);
+    /// ```
+    fn from(value: T) -> Self {
+        Gc::new(value)
     }
+}
 
-    impl<T: Trace, const N: usize> From<[T; N]> for Gc<[T]> {
-        /// Converts a [`[T; N]`](prim@array) into an `Gc<[T]>`.
-        ///
-        /// The conversion moves the array into a newly allocated `Gc`.
-        ///
-        /// # Example
-        ///
-        /// ```
-        /// # use dumpster::unsync::Gc;
-        /// let original: [i32; 3] = [1, 2, 3];
-        /// let shared: Gc<[i32]> = Gc::from(original);
-        /// assert_eq!(&[1, 2, 3], &shared[..]);
-        /// ```
-        #[inline]
-        fn from(v: [T; N]) -> Gc<[T]> {
-            unsync_coerce_gc!(Gc::<[T; N]>::from(v))
-        }
+impl<T: Trace, const N: usize> From<[T; N]> for Gc<[T]> {
+    /// Converts a [`[T; N]`](prim@array) into an `Gc<[T]>`.
+    ///
+    /// The conversion moves the array into a newly allocated `Gc`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use dumpster::unsync::Gc;
+    /// let original: [i32; 3] = [1, 2, 3];
+    /// let shared: Gc<[i32]> = Gc::from(original);
+    /// assert_eq!(&[1, 2, 3], &shared[..]);
+    /// ```
+    #[inline]
+    fn from(v: [T; N]) -> Gc<[T]> {
+        unsync_coerce_gc!(Gc::<[T; N]>::from(v))
     }
+}
 
-    impl<T: Trace + Clone> From<&[T]> for Gc<[T]> {
-        /// Allocates a garbage-collected slice and fills it by cloning `slice`'s items.
-        ///
-        /// # Example
-        ///
-        /// ```
-        /// # use dumpster::unsync::Gc;
-        /// let original: &[i32] = &[1, 2, 3];
-        /// let shared: Gc<[i32]> = Gc::from(original);
-        /// assert_eq!(&[1, 2, 3], &shared[..]);
-        /// ```
-        #[inline]
-        fn from(slice: &[T]) -> Gc<[T]> {
-            // Panic guard while cloning T elements.
-            // In the event of a panic, elements that have been written
-            // into the new GcBox will be dropped, then the memory freed.
-            struct Guard<T> {
-                /// pointer to `GcBox` to deallocate on panic
-                mem: *mut u8,
-                /// layout of the `GcBox` to deallocate on panic
-                layout: Layout,
-                /// pointer to the `GcBox`'s value
-                elems: *mut T,
-                /// the number of elements cloned so far
-                n_elems: usize,
-            }
+impl<T: Trace + Clone> From<&[T]> for Gc<[T]> {
+    /// Allocates a garbage-collected slice and fills it by cloning `slice`'s items.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use dumpster::unsync::Gc;
+    /// let original: &[i32] = &[1, 2, 3];
+    /// let shared: Gc<[i32]> = Gc::from(original);
+    /// assert_eq!(&[1, 2, 3], &shared[..]);
+    /// ```
+    #[inline]
+    fn from(slice: &[T]) -> Gc<[T]> {
+        // Panic guard while cloning T elements.
+        // In the event of a panic, elements that have been written
+        // into the new GcBox will be dropped, then the memory freed.
+        struct Guard<T> {
+            /// pointer to `GcBox` to deallocate on panic
+            mem: *mut u8,
+            /// layout of the `GcBox` to deallocate on panic
+            layout: Layout,
+            /// pointer to the `GcBox`'s value
+            elems: *mut T,
+            /// the number of elements cloned so far
+            n_elems: usize,
+        }
 
-            impl<T> Drop for Guard<T> {
-                fn drop(&mut self) {
-                    unsafe {
-                        let slice = slice::from_raw_parts_mut(self.elems, self.n_elems);
-                        ptr::drop_in_place(slice);
+        impl<T> Drop for Guard<T> {
+            fn drop(&mut self) {
+                unsafe {
+                    let slice = slice::from_raw_parts_mut(self.elems, self.n_elems);
+                    ptr::drop_in_place(slice);
 
-                        dealloc(self.mem, self.layout);
-                    }
-                }
-            }
-
-            unsafe {
-                let value_layout = Layout::array::<T>(slice.len()).unwrap();
-
-                let layout = Layout::new::<GcBox<()>>()
-                    .extend(value_layout)
-                    .unwrap()
-                    .0
-                    .pad_to_align();
-
-                let ptr = Self::allocate_for_layout_of_box(layout, |mem| {
-                    ptr::slice_from_raw_parts_mut(mem.cast::<T>(), slice.len()) as *mut GcBox<[T]>
-                });
-
-                // Pointer to first element
-                let elems = (&raw mut (*ptr).value).cast::<T>();
-
-                let mut guard = Guard {
-                    mem: ptr.cast::<u8>(),
-                    layout,
-                    elems,
-                    n_elems: 0,
-                };
-
-                for (i, item) in slice.iter().enumerate() {
-                    ptr::write(elems.add(i), item.clone());
-                    guard.n_elems += 1;
-                }
-
-                // All clear. Forget the guard so it doesn't free the new GcBox.
-                mem::forget(guard);
-
-                DUMPSTER.with(Dumpster::notify_created_gc);
-
-                Self {
-                    ptr: Cell::new(Nullable::from_ptr(ptr)),
+                    dealloc(self.mem, self.layout);
                 }
             }
         }
-    }
 
-    impl<T: Trace + Clone> From<&mut [T]> for Gc<[T]> {
-        /// Allocates a garbage-collected slice and fills it by cloning `v`'s items.
-        ///
-        /// # Example
-        ///
-        /// ```
-        /// # use dumpster::unsync::Gc;
-        /// let mut original = [1, 2, 3];
-        /// let original: &mut [i32] = &mut original;
-        /// let shared: Gc<[i32]> = Gc::from(original);
-        /// assert_eq!(&[1, 2, 3], &shared[..]);
-        /// ```
-        #[inline]
-        fn from(value: &mut [T]) -> Self {
-            Gc::from(&*value)
-        }
-    }
+        unsafe {
+            let value_layout = Layout::array::<T>(slice.len()).unwrap();
 
-    impl From<&str> for Gc<str> {
-        /// Allocates a garbage-collected string slice and copies `v` into it.
-        ///
-        /// # Example
-        ///
-        /// ```
-        /// # use dumpster::unsync::Gc;
-        /// let shared: Gc<str> = Gc::from("statue");
-        /// assert_eq!("statue", &shared[..]);
-        /// ```
-        #[inline]
-        fn from(v: &str) -> Self {
-            let bytes = Gc::<[u8]>::from(v.as_bytes());
-            unsafe { Gc::from_ptr(Gc::into_ptr(bytes) as *const GcBox<str>) }
-        }
-    }
+            let layout = Layout::new::<GcBox<()>>()
+                .extend(value_layout)
+                .unwrap()
+                .0
+                .pad_to_align();
 
-    impl From<&mut str> for Gc<str> {
-        /// Allocates a garbage-collected string slice and copies `v` into it.
-        ///
-        /// # Example
-        ///
-        /// ```
-        /// # use dumpster::unsync::Gc;
-        /// let mut original = String::from("statue");
-        /// let original: &mut str = &mut original;
-        /// let shared: Gc<str> = Gc::from(original);
-        /// assert_eq!("statue", &shared[..]);
-        /// ```
-        #[inline]
-        fn from(v: &mut str) -> Self {
-            Gc::from(&*v)
-        }
-    }
+            let ptr = Self::allocate_for_layout_of_box(layout, |mem| {
+                ptr::slice_from_raw_parts_mut(mem.cast::<T>(), slice.len()) as *mut GcBox<[T]>
+            });
 
-    impl From<Gc<str>> for Gc<[u8]> {
-        /// Converts a garbage-collected string slice into a byte slice.
-        ///
-        /// # Example
-        ///
-        /// ```
-        /// # use dumpster::unsync::Gc;
-        /// let string: Gc<str> = Gc::from("eggplant");
-        /// let bytes: Gc<[u8]> = Gc::from(string);
-        /// assert_eq!("eggplant".as_bytes(), bytes.as_ref());
-        /// ```
-        #[inline]
-        fn from(value: Gc<str>) -> Self {
-            unsafe { Gc::from_ptr(Gc::into_ptr(value) as *const GcBox<[u8]>) }
-        }
-    }
+            // Pointer to first element
+            let elems = (&raw mut (*ptr).value).cast::<T>();
 
-    impl From<String> for Gc<str> {
-        /// Allocates a garbage-collected string slice and copies `v` into it.
-        ///
-        /// # Example
-        ///
-        /// ```
-        /// # use dumpster::unsync::Gc;
-        /// let original: String = "statue".to_owned();
-        /// let shared: Gc<str> = Gc::from(original);
-        /// assert_eq!("statue", &shared[..]);
-        /// ```
-        #[inline]
-        fn from(value: String) -> Self {
-            Self::from(&value[..])
-        }
-    }
+            let mut guard = Guard {
+                mem: ptr.cast::<u8>(),
+                layout,
+                elems,
+                n_elems: 0,
+            };
 
-    impl<T: Trace> From<Box<T>> for Gc<T> {
-        /// Move a boxed object to a new, garbage collected, allocation.
-        ///
-        /// # Example
-        ///
-        /// ```
-        /// # use dumpster::unsync::Gc;
-        /// let original: Box<i32> = Box::new(1);
-        /// let shared: Gc<i32> = Gc::from(original);
-        /// assert_eq!(1, *shared);
-        /// ```
-        #[inline]
-        fn from(src: Box<T>) -> Self {
-            unsafe {
-                let layout = Layout::for_value(&*src);
-                let gc_ptr = Gc::allocate_for_layout(layout, <*mut u8>::cast::<GcBox<T>>);
+            for (i, item) in slice.iter().enumerate() {
+                ptr::write(elems.add(i), item.clone());
+                guard.n_elems += 1;
+            }
 
-                // Copy value as bytes
-                ptr::copy_nonoverlapping(
-                    (&raw const *src).cast::<u8>(),
-                    (&raw mut (*gc_ptr).value).cast::<u8>(),
-                    layout.size(),
-                );
+            // All clear. Forget the guard so it doesn't free the new GcBox.
+            mem::forget(guard);
 
-                // Free the allocation without dropping its contents
-                let bptr = Box::into_raw(src);
-                let src = Box::from_raw(bptr.cast::<mem::ManuallyDrop<T>>());
-                drop(src);
+            DUMPSTER.with(Dumpster::notify_created_gc);
 
-                DUMPSTER.with(Dumpster::notify_created_gc);
-                Self::from_ptr(gc_ptr)
+            Self {
+                ptr: Cell::new(Nullable::from_ptr(ptr)),
             }
         }
     }
+}
 
-    impl<T: Trace> From<Vec<T>> for Gc<[T]> {
-        /// Allocates a garbage-collected slice and moves `vec`'s items into it.
-        ///
-        /// # Example
-        ///
-        /// ```
-        /// # use dumpster::unsync::Gc;
-        /// let unique: Vec<i32> = vec![1, 2, 3];
-        /// let shared: Gc<[i32]> = Gc::from(unique);
-        /// assert_eq!(&[1, 2, 3], &shared[..]);
-        /// ```
-        #[inline]
-        fn from(vec: Vec<T>) -> Self {
-            let mut vec = ManuallyDrop::new(vec);
-            let vec_cap = vec.capacity();
-            let vec_len = vec.len();
-            let vec_ptr = vec.as_mut_ptr();
+impl<T: Trace + Clone> From<&mut [T]> for Gc<[T]> {
+    /// Allocates a garbage-collected slice and fills it by cloning `v`'s items.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use dumpster::unsync::Gc;
+    /// let mut original = [1, 2, 3];
+    /// let original: &mut [i32] = &mut original;
+    /// let shared: Gc<[i32]> = Gc::from(original);
+    /// assert_eq!(&[1, 2, 3], &shared[..]);
+    /// ```
+    #[inline]
+    fn from(value: &mut [T]) -> Self {
+        Gc::from(&*value)
+    }
+}
 
-            let gc_ptr = Self::allocate_for_slice(vec_len);
+impl From<&str> for Gc<str> {
+    /// Allocates a garbage-collected string slice and copies `v` into it.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use dumpster::unsync::Gc;
+    /// let shared: Gc<str> = Gc::from("statue");
+    /// assert_eq!("statue", &shared[..]);
+    /// ```
+    #[inline]
+    fn from(v: &str) -> Self {
+        let bytes = Gc::<[u8]>::from(v.as_bytes());
+        unsafe { Gc::from_ptr(Gc::into_ptr(bytes) as *const GcBox<str>) }
+    }
+}
 
-            unsafe {
-                let dst_ptr = (&raw mut (*gc_ptr).value).cast::<T>();
-                ptr::copy_nonoverlapping(vec_ptr, dst_ptr, vec_len);
+impl From<&mut str> for Gc<str> {
+    /// Allocates a garbage-collected string slice and copies `v` into it.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use dumpster::unsync::Gc;
+    /// let mut original = String::from("statue");
+    /// let original: &mut str = &mut original;
+    /// let shared: Gc<str> = Gc::from(original);
+    /// assert_eq!("statue", &shared[..]);
+    /// ```
+    #[inline]
+    fn from(v: &mut str) -> Self {
+        Gc::from(&*v)
+    }
+}
 
-                let _ = Vec::from_raw_parts(vec_ptr, 0, vec_cap);
+impl From<Gc<str>> for Gc<[u8]> {
+    /// Converts a garbage-collected string slice into a byte slice.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use dumpster::unsync::Gc;
+    /// let string: Gc<str> = Gc::from("eggplant");
+    /// let bytes: Gc<[u8]> = Gc::from(string);
+    /// assert_eq!("eggplant".as_bytes(), bytes.as_ref());
+    /// ```
+    #[inline]
+    fn from(value: Gc<str>) -> Self {
+        unsafe { Gc::from_ptr(Gc::into_ptr(value) as *const GcBox<[u8]>) }
+    }
+}
 
-                DUMPSTER.with(Dumpster::notify_created_gc);
-                Self::from_ptr(gc_ptr)
-            }
+impl From<String> for Gc<str> {
+    /// Allocates a garbage-collected string slice and copies `v` into it.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use dumpster::unsync::Gc;
+    /// let original: String = "statue".to_owned();
+    /// let shared: Gc<str> = Gc::from(original);
+    /// assert_eq!("statue", &shared[..]);
+    /// ```
+    #[inline]
+    fn from(value: String) -> Self {
+        Self::from(&value[..])
+    }
+}
+
+impl<T: Trace> From<Box<T>> for Gc<T> {
+    /// Move a boxed object to a new, garbage collected, allocation.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use dumpster::unsync::Gc;
+    /// let original: Box<i32> = Box::new(1);
+    /// let shared: Gc<i32> = Gc::from(original);
+    /// assert_eq!(1, *shared);
+    /// ```
+    #[inline]
+    fn from(src: Box<T>) -> Self {
+        unsafe {
+            let layout = Layout::for_value(&*src);
+            let gc_ptr = Gc::allocate_for_layout(layout, <*mut u8>::cast::<GcBox<T>>);
+
+            // Copy value as bytes
+            ptr::copy_nonoverlapping(
+                (&raw const *src).cast::<u8>(),
+                (&raw mut (*gc_ptr).value).cast::<u8>(),
+                layout.size(),
+            );
+
+            // Free the allocation without dropping its contents
+            let bptr = Box::into_raw(src);
+            let src = Box::from_raw(bptr.cast::<mem::ManuallyDrop<T>>());
+            drop(src);
+
+            DUMPSTER.with(Dumpster::notify_created_gc);
+            Self::from_ptr(gc_ptr)
         }
     }
+}
 
-    impl<'a, B: Trace> From<Cow<'a, B>> for Gc<B>
-    where
-        B: ToOwned + ?Sized,
-        Gc<B>: From<&'a B> + From<B::Owned>,
-    {
-        /// Creates a garbage-collected pointer from a clone-on-write pointer by
-        /// copying its content.
-        ///
-        /// # Example
-        ///
-        /// ```rust
-        /// # use dumpster::unsync::Gc;
-        /// # use std::borrow::Cow;
-        /// let cow: Cow<'_, str> = Cow::Borrowed("eggplant");
-        /// let shared: Gc<str> = Gc::from(cow);
-        /// assert_eq!("eggplant", &shared[..]);
-        /// ```
-        #[inline]
-        fn from(cow: Cow<'a, B>) -> Gc<B> {
-            match cow {
-                Cow::Borrowed(s) => Gc::from(s),
-                Cow::Owned(s) => Gc::from(s),
-            }
+impl<T: Trace> From<Vec<T>> for Gc<[T]> {
+    /// Allocates a garbage-collected slice and moves `vec`'s items into it.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use dumpster::unsync::Gc;
+    /// let unique: Vec<i32> = vec![1, 2, 3];
+    /// let shared: Gc<[i32]> = Gc::from(unique);
+    /// assert_eq!(&[1, 2, 3], &shared[..]);
+    /// ```
+    #[inline]
+    fn from(vec: Vec<T>) -> Self {
+        let mut vec = ManuallyDrop::new(vec);
+        let vec_cap = vec.capacity();
+        let vec_len = vec.len();
+        let vec_ptr = vec.as_mut_ptr();
+
+        let gc_ptr = Self::allocate_for_slice(vec_len);
+
+        unsafe {
+            let dst_ptr = (&raw mut (*gc_ptr).value).cast::<T>();
+            ptr::copy_nonoverlapping(vec_ptr, dst_ptr, vec_len);
+
+            let _ = Vec::from_raw_parts(vec_ptr, 0, vec_cap);
+
+            DUMPSTER.with(Dumpster::notify_created_gc);
+            Self::from_ptr(gc_ptr)
+        }
+    }
+}
+
+impl<'a, B: Trace> From<Cow<'a, B>> for Gc<B>
+where
+    B: ToOwned + ?Sized,
+    Gc<B>: From<&'a B> + From<B::Owned>,
+{
+    /// Creates a garbage-collected pointer from a clone-on-write pointer by
+    /// copying its content.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use dumpster::unsync::Gc;
+    /// # use std::borrow::Cow;
+    /// let cow: Cow<'_, str> = Cow::Borrowed("eggplant");
+    /// let shared: Gc<str> = Gc::from(cow);
+    /// assert_eq!("eggplant", &shared[..]);
+    /// ```
+    #[inline]
+    fn from(cow: Cow<'a, B>) -> Gc<B> {
+        match cow {
+            Cow::Borrowed(s) => Gc::from(s),
+            Cow::Owned(s) => Gc::from(s),
         }
     }
 }


### PR DESCRIPTION
I think it's a good idea to add a project-wide notice about including code from std. That way past and future changes don't have to annotate every code portions that are derived from std.

For instance to implement the check for ref count overflow I would have wanted to add the comments from std, but adding a license blurb for each comment would just be noisy and annoying.

This PR:
- explains in the readme that this project contains code derived from std
- adds the `LICENSE-MIT` and `LICENSE-APACHE` files copied from `rust-lang/rust`;
  this is required to comply with the licenses
- removes the previous attribution of the `From` implementations

