### PR TITLE
Export coerce macros as `{sync, unsync}::coerce_gc`

### DIFF
--- a/dumpster/src/sync/mod.rs
+++ b/dumpster/src/sync/mod.rs
@@ -477,7 +477,7 @@ where
         }
     }
 
-    /// Exists solely for the [`sync_coerce_gc`] macro.
+    /// Exists solely for the [`coerce_gc`] macro.
     #[inline]
     #[must_use]
     #[doc(hidden)]
@@ -485,7 +485,7 @@ where
         Self::into_ptr(this)
     }
 
-    /// Exists solely for the [`sync_coerce_gc`] macro.
+    /// Exists solely for the [`coerce_gc`] macro.
     #[inline]
     #[must_use]
     #[doc(hidden)]
@@ -559,10 +559,10 @@ impl<T: Trace + Send + Sync + Clone> Gc<T> {
 /// # Examples
 ///
 /// ```
-/// use dumpster::{sync::Gc, sync_coerce_gc};
+/// use dumpster::sync::{coerce_gc, Gc};
 ///
 /// let gc1: Gc<[u8; 3]> = Gc::new([7, 8, 9]);
-/// let gc2: Gc<[u8]> = sync_coerce_gc!(gc1);
+/// let gc2: Gc<[u8]> = coerce_gc!(gc1);
 /// assert_eq!(&gc2[..], &[7, 8, 9]);
 /// ```
 ///
@@ -571,19 +571,23 @@ impl<T: Trace + Send + Sync + Clone> Gc<T> {
 ///
 /// ```compile_fail
 /// // This program is incorrect!
-/// use dumpster::{sync::Gc, sync_coerce_gc};
+/// use dumpster::sync::{Gc, coerce_gc};
 ///
 /// let gc1: Gc<u8> = Gc::new(1);
-/// let gc2: Gc<i8> = sync_coerce_gc!(gc1);
+/// let gc2: Gc<i8> = coerce_gc!(gc1);
 /// ```
+#[doc(hidden)]
 #[macro_export]
-macro_rules! sync_coerce_gc {
+macro_rules! __sync_coerce_gc {
     ($gc:expr) => {{
         // Temporarily convert the `Gc` into a raw pointer to allow for coercion to occur.
         let (ptr, tag): (*const _, usize) = $crate::sync::Gc::__private_into_ptr($gc);
         unsafe { $crate::sync::Gc::__private_from_ptr(ptr, tag) }
     }};
 }
+
+#[doc(inline)]
+pub use crate::__sync_coerce_gc as coerce_gc;
 
 impl<T> Clone for Gc<T>
 where
@@ -993,7 +997,7 @@ impl<T: Trace + Send + Sync, const N: usize> From<[T; N]> for Gc<[T]> {
     /// ```
     #[inline]
     fn from(v: [T; N]) -> Gc<[T]> {
-        sync_coerce_gc!(Gc::<[T; N]>::from(v))
+        coerce_gc!(Gc::<[T; N]>::from(v))
     }
 }
 

--- a/dumpster/src/sync/tests.rs
+++ b/dumpster/src/sync/tests.rs
@@ -16,7 +16,7 @@ use std::{
     },
 };
 
-use crate::{sync_coerce_gc, Visitor};
+use crate::{sync::coerce_gc, Visitor};
 
 use super::*;
 
@@ -289,7 +289,7 @@ fn coerce_array() {
 #[test]
 fn coerce_array_using_macro() {
     let gc1: Gc<[u8; 3]> = Gc::new([0, 0, 0]);
-    let gc2: Gc<[u8]> = sync_coerce_gc!(gc1);
+    let gc2: Gc<[u8]> = coerce_gc!(gc1);
     assert_eq!(gc2.len(), 3);
     assert_eq!(
         std::mem::size_of::<Gc<[u8]>>(),

--- a/dumpster/src/unsync/mod.rs
+++ b/dumpster/src/unsync/mod.rs
@@ -437,7 +437,7 @@ impl<T: Trace + ?Sized> Gc<T> {
         }
     }
 
-    /// Exists solely for the [`unsync_coerce_gc`] macro.
+    /// Exists solely for the [`coerce_gc`] macro.
     #[inline]
     #[must_use]
     #[doc(hidden)]
@@ -445,7 +445,7 @@ impl<T: Trace + ?Sized> Gc<T> {
         Self::into_ptr(this)
     }
 
-    /// Exists solely for the [`unsync_coerce_gc`] macro.
+    /// Exists solely for the [`coerce_gc`] macro.
     #[inline]
     #[must_use]
     #[doc(hidden)]
@@ -577,10 +577,10 @@ impl<T: Trace> Gc<[T]> {
 /// # Examples
 ///
 /// ```
-/// use dumpster::{unsync::Gc, unsync_coerce_gc};
+/// use dumpster::unsync::{coerce_gc, Gc};
 ///
 /// let gc1: Gc<[u8; 3]> = Gc::new([7, 8, 9]);
-/// let gc2: Gc<[u8]> = unsync_coerce_gc!(gc1);
+/// let gc2: Gc<[u8]> = coerce_gc!(gc1);
 /// assert_eq!(&gc2[..], &[7, 8, 9]);
 /// ```
 ///
@@ -589,19 +589,23 @@ impl<T: Trace> Gc<[T]> {
 ///
 /// ```compile_fail
 /// // This program is incorrect!
-/// use dumpster::{unsync::Gc, unsync_coerce_gc};
+/// use dumpster::unsync::{Gc, coerce_gc};
 ///
 /// let gc1: Gc<u8> = Gc::new(1);
-/// let gc2: Gc<i8> = unsync_coerce_gc!(gc1);
+/// let gc2: Gc<i8> = coerce_gc!(gc1);
 /// ```
+#[doc(hidden)]
 #[macro_export]
-macro_rules! unsync_coerce_gc {
+macro_rules! __unsync_coerce_gc {
     ($gc:expr) => {{
         // Temporarily convert the `Gc` into a raw pointer to allow for coercion to occur.
         let ptr: *const _ = $crate::unsync::Gc::__private_into_ptr($gc);
         unsafe { $crate::unsync::Gc::__private_from_ptr(ptr) }
     }};
 }
+
+#[doc(inline)]
+pub use crate::__unsync_coerce_gc as coerce_gc;
 
 impl<T: Trace + ?Sized> Deref for Gc<T> {
     type Target = T;
@@ -917,7 +921,7 @@ impl<T: Trace, const N: usize> From<[T; N]> for Gc<[T]> {
     /// ```
     #[inline]
     fn from(v: [T; N]) -> Gc<[T]> {
-        unsync_coerce_gc!(Gc::<[T; N]>::from(v))
+        coerce_gc!(Gc::<[T; N]>::from(v))
     }
 }
 

--- a/dumpster/src/unsync/tests.rs
+++ b/dumpster/src/unsync/tests.rs
@@ -8,7 +8,7 @@
 
 //! Simple tests using manual implementations of [`Trace`].
 
-use crate::{unsync_coerce_gc, Visitor};
+use crate::{unsync::coerce_gc, Visitor};
 
 use super::*;
 use std::{
@@ -259,7 +259,7 @@ fn coerce_array() {
 #[test]
 fn coerce_array_using_macro() {
     let gc1: Gc<[u8; 3]> = Gc::new([0, 0, 0]);
-    let gc2: Gc<[u8]> = unsync_coerce_gc!(gc1);
+    let gc2: Gc<[u8]> = coerce_gc!(gc1);
     assert_eq!(gc2.len(), 3);
     assert_eq!(
         std::mem::size_of::<Gc<[u8]>>(),


### PR DESCRIPTION
I just found out that we don't have to have the macros be at the crate root.

We can instead re-export the coercion macros in their respective modules and hide the `#[macro_export]`ed ones.

The documentation looks good, it doesn't show that it's re-exported but looks just like as if the macro was defined normally.