### PR TITLE
Rework `Trace` trait to be dyn compatible

### DIFF
--- a/dumpster/src/sync/loom_ext.rs
+++ b/dumpster/src/sync/loom_ext.rs
@@ -23,13 +23,13 @@ use loom::{
     },
 };
 
-use crate::{Trace, Visitor};
+use crate::{TraceWith, Visitor};
 
 /// Simple wrapper mutex type.
 pub struct Mutex<T: ?Sized>(MutexImpl<T>);
 
-unsafe impl<T: Trace + ?Sized> Trace for Mutex<T> {
-    fn accept<V: Visitor>(&self, visitor: &mut V) -> Result<(), ()> {
+unsafe impl<V: Visitor, T: TraceWith<V> + ?Sized> TraceWith<V> for Mutex<T> {
+    fn accept(&self, visitor: &mut V) -> Result<(), ()> {
         self.0
             .try_lock()
             .map_err(|e| match e {
@@ -122,8 +122,8 @@ pub struct OnceLock<T> {
 unsafe impl<T: Sync + Send> Sync for OnceLock<T> {}
 unsafe impl<T: Send> Send for OnceLock<T> {}
 
-unsafe impl<T: Trace> Trace for OnceLock<T> {
-    fn accept<V: Visitor>(&self, visitor: &mut V) -> Result<(), ()> {
+unsafe impl<V: Visitor, T: TraceWith<V>> TraceWith<V> for OnceLock<T> {
+    fn accept(&self, visitor: &mut V) -> Result<(), ()> {
         self.with(|value| value.accept(visitor)).unwrap_or(Ok(()))
     }
 }

--- a/dumpster/src/sync/loom_tests.rs
+++ b/dumpster/src/sync/loom_tests.rs
@@ -25,8 +25,8 @@ impl Drop for DropCount<'_> {
     }
 }
 
-unsafe impl Trace for DropCount<'_> {
-    fn accept<V: crate::Visitor>(&self, _: &mut V) -> Result<(), ()> {
+unsafe impl<V: Visitor> TraceWith<V> for DropCount<'_> {
+    fn accept(&self, _: &mut V) -> Result<(), ()> {
         Ok(())
     }
 }
@@ -37,8 +37,8 @@ struct MultiRef {
     count: DropCount<'static>,
 }
 
-unsafe impl Trace for MultiRef {
-    fn accept<V: Visitor>(&self, visitor: &mut V) -> Result<(), ()> {
+unsafe impl<V: Visitor> TraceWith<V> for MultiRef {
+    fn accept(&self, visitor: &mut V) -> Result<(), ()> {
         self.refs.accept(visitor)
     }
 }
@@ -68,8 +68,8 @@ fn loom_self_referential() {
         static ref DROP_COUNT: AtomicUsize = AtomicUsize::new(0);
     }
 
-    unsafe impl Trace for Foo {
-        fn accept<V: Visitor>(&self, visitor: &mut V) -> Result<(), ()> {
+    unsafe impl<V: Visitor> TraceWith<V> for Foo {
+        fn accept(&self, visitor: &mut V) -> Result<(), ()> {
             self.0.accept(visitor)
         }
     }
@@ -135,14 +135,14 @@ fn loom_sync_leak_by_creation_in_drop() {
     struct Foo(OnceLock<Gc<Self>>, usize);
     struct Bar(OnceLock<Gc<Self>>, usize);
 
-    unsafe impl Trace for Foo {
-        fn accept<V: Visitor>(&self, visitor: &mut V) -> Result<(), ()> {
+    unsafe impl<V: Visitor> TraceWith<V> for Foo {
+        fn accept(&self, visitor: &mut V) -> Result<(), ()> {
             self.0.accept(visitor)
         }
     }
 
-    unsafe impl Trace for Bar {
-        fn accept<V: Visitor>(&self, visitor: &mut V) -> Result<(), ()> {
+    unsafe impl<V: Visitor> TraceWith<V> for Bar {
+        fn accept(&self, visitor: &mut V) -> Result<(), ()> {
             self.0.accept(visitor)
         }
     }


### PR DESCRIPTION
This PR makes `Trace` dyn compatible.

### Motivation

With a dyn compatible `Trace` trait you will be able to store trait objects in `Gc` pointers:

```rust
trait MyTrait: Trace + Send + Sync {}
impl MyTrait for i32 {}

let gc = Gc::new(5i32);
let gc: Gc<dyn MyTrait> = coerce_gc!(gc);
```

### Implementation

To make this work I've first moved the `V: Visitor` generic param from the method to the trait itself:

```rust
// Before
pub unsafe trait Trace {
    fn accept<V: Visitor>(&self, visitor: &mut V) -> Result<(), ()>;
}

// After
pub unsafe trait Trace<V: Visitor> {
    fn accept(&self, visitor: &mut V) -> Result<(), ()>;
}
```

This makes it possible to have dyn compatible, albeit visitor specific trace traits like `Trace<Dfs>`.

Then, to be able to have a trait for all our visitors I've renamed that `Trace` trait to `TraceWith` and created a new `Trace` trait as a sub trait of all the visitor specific `TraceWith` traits:

```rust
trait Trace: 
    TraceWith<ContainsGcs> + 
    TraceWith<Dfs> + 
    TraceWith<PrepareForDestruction> + ...
{}

impl<T> Trace for T 
where T: 
    TraceWith<ConstainsGcs> + 
    TraceWith<Dfs> + 
    TraceWith<PrepareForDestruction> + ...
{}
```
*(The `Trace` trait doesn't look quite like that, I've hidden the implementation details.)*

To implement `Trace` you then implement `TraceWith<V>` for all `V: Visitor`:

```rust
unsafe impl<V: Visitor> TraceWith<V> for Foo {
    fn accept(&self, _: &mut V) -> Result<(), ()> {
        todo!()
    }
}
```

These changes were mostly mechanical, occasionally moving a visitor out of a function so that it can be added to `Trace`.

One case that required more attention is the `Rehydrate` visitor. On main this is 
`struct Rehydrate<U: Trace + 'static>(...)` which wouldn't be dyn compatible. So instead of the `U` type parameter, `Rehydrate` now has a `TypeId` field. In its `visit_unsync` method I've moved the `gc.is_dead()` check before the type id equality checks in the if expression because checking if a gc is dead is faster than a type id comparison. That's all.