### PR TITLE
Remove `GarbageTruck`'s drop implementation

### DIFF
--- a/dumpster/src/sync/collect.rs
+++ b/dumpster/src/sync/collect.rs
@@ -672,10 +672,3 @@ impl Drop for Dumpster {
         // collect_all();
     }
 }
-
-#[cfg(not(loom))] // cannot access lazy static in drop
-impl Drop for GarbageTruck {
-    fn drop(&mut self) {
-        GARBAGE_TRUCK.collect_all();
-    }
-}


### PR DESCRIPTION
The drop implementation is dead code since

> Static items do not call `drop` at the end of the program.[^1]

and `GarbageTruck` is only used as a static.

[^1]: https://doc.rust-lang.org/std/keyword.static.html
