### PR TITLE
Add attribute to `#[derive(Trace)]` for choosing `dumpster` crate path

### DIFF
--- a/dumpster/src/lib.rs
+++ b/dumpster/src/lib.rs
@@ -378,6 +378,19 @@ extern crate dumpster_derive;
 ///     bar: Option<Box<Foo>>,
 /// }
 /// ```
+///
+/// You can specify the crate path for the `dumpster` crate using the `dumpster` attribute:
+///
+/// ```
+/// use dumpster as dumpster_renamed;
+/// use dumpster_renamed::Trace;
+///
+/// #[derive(Trace)]
+/// #[dumpster(crate = dumpster_renamed)]
+/// struct Foo {
+///     bar: Option<Box<Foo>>,
+/// }
+/// ```
 pub use dumpster_derive::Trace;
 
 /// Determine whether some value contains a garbage-collected pointer.


### PR DESCRIPTION
This PR adds the ability to configure the path for the dumpster crate.

This can be useful for other library crates that use their own macros that may want to derive `Trace` without the library user having to depend on `dumpster` directly. They would re-export `dumpster` instead:

```rust
#[derive(::my_library::dumpster::Trace)]
#[dumpster(crate = ::my_library::dumpster)]
struct Foo {
   ...
}
```

I've also found it useful to be able to benchmark two versions of dumpster in `dumpster_bench` with a `Cargo.toml` like:
```toml
dumpster_pr = { version = "1.1.0", path = "../dumpster", features = [
    "derive",
], package = "dumpster" }
dumpster_main = { git = "https://github.com/bluurryy/dumpster", branch = "allow-choosing-crate-path-in-derive-macro", features = [
    "derive",
], package = "dumpster" }
```

and a lib.rs like:
```rust
#[derive(dumpster_main::Trace, Debug)]
#[dumpster(crate = dumpster_main)]
pub struct DumpsterMainSyncMultiref {
    refs: Mutex<Vec<dumpster_main::sync::Gc<Self>>>,
}

// ...

#[derive(dumpster_pr::Trace, Debug)]
#[dumpster(crate = dumpster_pr)]
pub struct DumpsterPrSyncMultiref {
    refs: Mutex<Vec<dumpster_pr::sync::Gc<Self>>>,
}
```