### PR TITLE
feat!: turn remaining public `Gc` methods into associated functions

### DIFF
--- a/dumpster/src/sync/collect.rs
+++ b/dumpster/src/sync/collect.rs
@@ -509,7 +509,7 @@ impl Visitor for Dfs<'_> {
     where
         T: Trace + Send + Sync + ?Sized,
     {
-        if gc.is_dead() {
+        if Gc::is_dead(gc) {
             return;
         }
         // must not use deref operators since we don't want to update the generation
@@ -621,7 +621,7 @@ impl Visitor for PrepareForDestruction<'_> {
     where
         T: Trace + Send + Sync + ?Sized,
     {
-        if gc.is_dead() {
+        if Gc::is_dead(gc) {
             return;
         }
         let id = AllocationId::from(unsafe {

--- a/dumpster/src/sync/tests.rs
+++ b/dumpster/src/sync/tests.rs
@@ -813,7 +813,7 @@ fn make_mut_of_object_in_dumpster() {
 
     // now foo is in the dumpster
     // and its ref count is one
-    assert_eq!(foo.ref_count().get(), 1);
+    assert_eq!(Gc::ref_count(&foo).get(), 1);
 
     // we get a mut reference
     let foo_mut = Gc::make_mut(&mut foo);
@@ -913,7 +913,7 @@ fn new_cyclic_simple() {
         }
     }
     let gc = Gc::new_cyclic(Cycle);
-    assert_eq!(gc.ref_count().get(), 2);
+    assert_eq!(Gc::ref_count(&gc).get(), 2);
     drop(gc);
 }
 

--- a/dumpster/src/unsync/collect.rs
+++ b/dumpster/src/unsync/collect.rs
@@ -259,7 +259,7 @@ impl Visitor for Dfs {
     where
         T: Trace + ?Sized,
     {
-        if gc.is_dead() {
+        if Gc::is_dead(gc) {
             return;
         }
         let ptr = gc.ptr.get().unwrap();
@@ -301,7 +301,7 @@ impl Visitor for Mark {
     where
         T: Trace + ?Sized,
     {
-        if gc.is_dead() {
+        if Gc::is_dead(gc) {
             return;
         }
         let ptr = gc.ptr.get().unwrap();
@@ -331,7 +331,7 @@ impl Visitor for DropAlloc<'_> {
     where
         T: Trace + ?Sized,
     {
-        if gc.is_dead() {
+        if Gc::is_dead(gc) {
             return;
         }
         let ptr = gc.ptr.get().unwrap();

--- a/dumpster/src/unsync/mod.rs
+++ b/dumpster/src/unsync/mod.rs
@@ -334,7 +334,7 @@ impl<T: Trace + ?Sized> Gc<T> {
         let nilgc = Gc {
             ptr: Cell::new(Nullable::new(gcbox.cast::<GcBox<T>>()).as_null()),
         };
-        assert!(nilgc.is_dead());
+        assert!(Gc::is_dead(&nilgc));
         unsafe {
             // SAFETY: `gcbox` is a valid pointer to an uninitialized datum that we have allocated.
             gcbox.as_mut().value = Uninitialized(MaybeUninit::new(data_fn(nilgc)));
@@ -509,14 +509,14 @@ impl<T: Trace + ?Sized> Gc<T> {
     /// use dumpster::unsync::Gc;
     ///
     /// let gc = Gc::new(());
-    /// assert_eq!(gc.ref_count().get(), 1);
+    /// assert_eq!(Gc::ref_count(&gc).get(), 1);
     /// let gc2 = gc.clone();
-    /// assert_eq!(gc.ref_count().get(), 2);
+    /// assert_eq!(Gc::ref_count(&gc).get(), 2);
     /// drop(gc);
     /// drop(gc2);
     /// ```
-    pub fn ref_count(&self) -> NonZeroUsize {
-        let box_ptr = self.ptr.get().expect(
+    pub fn ref_count(gc: &Self) -> NonZeroUsize {
+        let box_ptr = gc.ptr.get().expect(
             "Attempt to dereference Gc to already-collected object. \
     This means a Gc escaped from a Drop implementation, likely implying a bug in your code.",
         );
@@ -542,7 +542,7 @@ impl<T: Trace + ?Sized> Gc<T> {
     ///
     /// impl Drop for Cycle {
     ///     fn drop(&mut self) {
-    ///         assert!(self.0.is_dead());
+    ///         assert!(Gc::is_dead(&self.0));
     ///     }
     /// }
     ///
@@ -550,8 +550,8 @@ impl<T: Trace + ?Sized> Gc<T> {
     /// # drop(gc1);
     /// # dumpster::unsync::collect();
     /// ```
-    pub fn is_dead(&self) -> bool {
-        self.ptr.get().is_null()
+    pub fn is_dead(gc: &Self) -> bool {
+        gc.ptr.get().is_null()
     }
 
     /// Consumes the `Gc<T>`, returning the inner `GcBox<T>` pointer.
@@ -614,7 +614,7 @@ impl Visitor for Rehydrate {
     where
         T: Trace + ?Sized,
     {
-        if gc.is_dead() && TypeId::of::<T>() == self.type_id {
+        if Gc::is_dead(gc) && TypeId::of::<T>() == self.type_id {
             unsafe {
                 // SAFETY: it is safe to transmute these pointers because we have checked
                 // that they are of the same type.
@@ -667,7 +667,7 @@ impl<T: Trace + Clone> Gc<T> {
     /// ```
     #[inline]
     pub fn make_mut(this: &mut Self) -> &mut T {
-        if this.is_dead() {
+        if Gc::is_dead(this) {
             panic_deref_of_collected_object();
         }
 

--- a/dumpster/src/unsync/tests.rs
+++ b/dumpster/src/unsync/tests.rs
@@ -329,7 +329,7 @@ fn from_box() {
     // construct the `Gc`.
     //
     // Here we ensure that the metadata is initialized to a valid state.
-    assert_eq!(gc.ref_count().get(), 1);
+    assert_eq!(Gc::ref_count(&gc).get(), 1);
 
     assert_eq!(&*gc, "hello");
 }
@@ -342,7 +342,7 @@ fn from_slice() {
     // construct the `Gc`.
     //
     // Here we ensure that the metadata is initialized to a valid state.
-    assert_eq!(gc.ref_count().get(), 1);
+    assert_eq!(Gc::ref_count(&gc).get(), 1);
 
     assert_eq!(&*gc, ["hello", "world"]);
 }
@@ -398,7 +398,7 @@ fn from_vec() {
     // construct the `Gc`.
     //
     // Here we ensure that the metadata is initialized to a valid state.
-    assert_eq!(gc.ref_count().get(), 1);
+    assert_eq!(Gc::ref_count(&gc).get(), 1);
 
     assert_eq!(&*gc, ["hello", "world"]);
 }
@@ -472,7 +472,7 @@ fn make_mut_of_object_in_dumpster() {
 
     // now foo is in the dumpster
     // and its ref count is one
-    assert_eq!(foo.ref_count().get(), 1);
+    assert_eq!(Gc::ref_count(&foo).get(), 1);
 
     // we get a mut reference
     let foo_mut = Gc::make_mut(&mut foo);
@@ -529,7 +529,7 @@ fn new_cyclic_one() {
     }
 
     let cyc = Gc::new_cyclic(|gc| Cycle(gc, DropCount(&DROP_COUNT)));
-    assert_eq!(cyc.ref_count().get(), 2);
+    assert_eq!(Gc::ref_count(&cyc).get(), 2);
     drop(cyc);
     collect();
 


### PR DESCRIPTION
This affects `Gc::ref_count` and `Gc::is_dead`.

If we make them associated functions instead of methods we can avoid conflicts with methods of the inner type `T`. So that...

```rust
impl Monster { fn is_dead(&self) { ... } }

let monster: Gc<Monster> = ...
monster.is_dead()
```

...calls `Monster`'s method, and not one from `Gc`.

`Rc`, `Arc` and `Box` also use associated functions instead of methods because of that reason.
