### PR TITLE
docs: remove module prefix from `Gc` in `coerce_gc` docs

### DIFF
--- a/dumpster/src/sync/mod.rs
+++ b/dumpster/src/sync/mod.rs
@@ -771,7 +771,7 @@ impl<T: Trace + Send + Sync + Clone> Gc<T> {
     }
 }
 
-/// Allows coercing `T` of [`sync::Gc<T>`](Gc).
+/// Allows coercing `T` of [`Gc<T>`](Gc).
 ///
 /// This means that you can convert a `Gc` containing a strictly-sized type (such as `[T; N]`) into
 /// a `Gc` containing its unsized version (such as `[T]`), all without using nightly-only features.

--- a/dumpster/src/unsync/mod.rs
+++ b/dumpster/src/unsync/mod.rs
@@ -748,7 +748,7 @@ impl<T: Trace> Gc<[T]> {
     }
 }
 
-/// Allows coercing `T` of [`unsync::Gc<T>`](Gc).
+/// Allows coercing `T` of [`Gc<T>`](Gc).
 ///
 /// This means that you can convert a `Gc` containing a strictly-sized type (such as `[T; N]`) into
 /// a `Gc` containing its unsized version (such as `[T]`), all without using nightly-only features.


### PR DESCRIPTION
This was useful when `coerce_gc` was exported at crate root as `unsync_coerce_gc` etc. I think it's nicer now without the prefix.