### PR TITLE
`T` does not need to be `Send + Sync` for `Display` blanket implementation in `unsync` module

### DIFF
--- a/dumpster/src/unsync/mod.rs
+++ b/dumpster/src/unsync/mod.rs
@@ -1061,7 +1061,7 @@ where
 {
 }
 
-impl<T: Trace + Send + Sync + Display + ?Sized> Display for Gc<T> {
+impl<T: Trace + Display + ?Sized> Display for Gc<T> {
     /// Formats the value using its `Display` implementation.
     ///
     /// # Note


### PR DESCRIPTION
This is a follow-up PR to #70 (issue #69): I mistakenly included the `Send + Sync` constraint for the `Display` blanket implementation in the `unsync`  module which is not required. This PR fixes this.