### PR TITLE
feat!: Create separate trait for containing Gcs

### DIFF
--- a/dumpster/src/impls.rs
+++ b/dumpster/src/impls.rs
@@ -31,11 +31,31 @@ use std::{
     },
 };
 
-use crate::{TraceWith, Visitor};
+use crate::{ContainsGcs, ContainsGcsVisitor, TraceWith, Visitor};
+
+impl ContainsGcs for Infallible {
+    fn contains_gcs(&self, _: &mut ContainsGcsVisitor) -> bool {
+        false
+    }
+}
 
 unsafe impl<V: Visitor> TraceWith<V> for Infallible {
     fn accept(&self, _: &mut V) -> Result<(), ()> {
         match *self {}
+    }
+}
+
+#[cfg(feature = "either")]
+impl<A: ContainsGcs, B: ContainsGcs> ContainsGcs for either::Either<A, B> {
+    fn contains_gcs(&self, visitor: &mut ContainsGcsVisitor) -> bool {
+        if visitor.consume_fuel().is_err() {
+            return true;
+        }
+
+        match self {
+            either::Either::Left(a) => a.contains_gcs(visitor),
+            either::Either::Right(b) => b.contains_gcs(visitor),
+        }
     }
 }
 
@@ -52,6 +72,12 @@ unsafe impl<V: Visitor, A: TraceWith<V>, B: TraceWith<V>> TraceWith<V> for eithe
 /// Implement `TraceWith<V>` trivially for some parametric `?Sized` type.
 macro_rules! param_trivial_impl_unsized {
     ($x: ty) => {
+        impl<T: ?Sized> ContainsGcs for $x {
+            fn contains_gcs(&self, _: &mut ContainsGcsVisitor) -> bool {
+                false
+            }
+        }
+
         unsafe impl<V: Visitor, T: ?Sized> TraceWith<V> for $x {
             #[inline]
             fn accept(&self, _: &mut V) -> Result<(), ()> {
@@ -69,6 +95,12 @@ param_trivial_impl_unsized!(PhantomData<T>);
 /// Implement `TraceWith<V>` trivially for some parametric `Sized` type.
 macro_rules! param_trivial_impl_sized {
     ($x: ty) => {
+        impl<T> ContainsGcs for $x {
+            fn contains_gcs(&self, _: &mut ContainsGcsVisitor) -> bool {
+                false
+            }
+        }
+
         unsafe impl<V: Visitor, T> TraceWith<V> for $x {
             #[inline]
             fn accept(&self, _: &mut V) -> Result<(), ()> {
@@ -81,15 +113,50 @@ macro_rules! param_trivial_impl_sized {
 param_trivial_impl_sized!(std::future::Pending<T>);
 param_trivial_impl_sized!(std::mem::Discriminant<T>);
 
+impl<T: ContainsGcs + ?Sized> ContainsGcs for Box<T> {
+    fn contains_gcs(&self, visitor: &mut ContainsGcsVisitor) -> bool {
+        if visitor.consume_fuel().is_err() {
+            return true;
+        }
+
+        (**self).contains_gcs(visitor)
+    }
+}
+
 unsafe impl<V: Visitor, T: TraceWith<V> + ?Sized> TraceWith<V> for Box<T> {
     fn accept(&self, visitor: &mut V) -> Result<(), ()> {
         (**self).accept(visitor)
     }
 }
 
+impl<T> ContainsGcs for BuildHasherDefault<T> {
+    fn contains_gcs(&self, _: &mut ContainsGcsVisitor) -> bool {
+        false
+    }
+}
+
 unsafe impl<V: Visitor, T> TraceWith<V> for BuildHasherDefault<T> {
     fn accept(&self, _: &mut V) -> Result<(), ()> {
         Ok(())
+    }
+}
+
+impl<T: ToOwned + ?Sized> ContainsGcs for Cow<'_, T>
+where
+    T::Owned: ContainsGcs,
+{
+    fn contains_gcs(&self, visitor: &mut ContainsGcsVisitor) -> bool {
+        if visitor.consume_fuel().is_err() {
+            return true;
+        }
+
+        if let Cow::Owned(ref v) = self {
+            if v.contains_gcs(visitor) {
+                return true;
+            }
+        }
+
+        false
     }
 }
 
@@ -105,10 +172,39 @@ where
     }
 }
 
+impl<T: ContainsGcs + ?Sized> ContainsGcs for RefCell<T> {
+    #[inline]
+    fn contains_gcs(&self, visitor: &mut ContainsGcsVisitor) -> bool {
+        if visitor.consume_fuel().is_err() {
+            return true;
+        }
+
+        match self.try_borrow() {
+            Ok(value) => value.contains_gcs(visitor),
+            Err(_) => true,
+        }
+    }
+}
+
 unsafe impl<V: Visitor, T: TraceWith<V> + ?Sized> TraceWith<V> for RefCell<T> {
     #[inline]
     fn accept(&self, visitor: &mut V) -> Result<(), ()> {
         self.try_borrow().map_err(|_| ())?.accept(visitor)
+    }
+}
+
+impl<T: ContainsGcs + ?Sized> ContainsGcs for Mutex<T> {
+    #[inline]
+    fn contains_gcs(&self, visitor: &mut ContainsGcsVisitor) -> bool {
+        if visitor.consume_fuel().is_err() {
+            return true;
+        }
+
+        match self.try_lock() {
+            Ok(value) => value.deref().contains_gcs(visitor),
+            Err(TryLockError::Poisoned(_)) => panic!(),
+            Err(TryLockError::WouldBlock) => true,
+        }
     }
 }
 
@@ -125,6 +221,21 @@ unsafe impl<V: Visitor, T: TraceWith<V> + ?Sized> TraceWith<V> for Mutex<T> {
     }
 }
 
+impl<T: ContainsGcs + ?Sized> ContainsGcs for RwLock<T> {
+    #[inline]
+    fn contains_gcs(&self, visitor: &mut ContainsGcsVisitor) -> bool {
+        if visitor.consume_fuel().is_err() {
+            return true;
+        }
+
+        match self.try_read() {
+            Ok(value) => value.deref().contains_gcs(visitor),
+            Err(TryLockError::Poisoned(_)) => panic!(),
+            Err(TryLockError::WouldBlock) => true,
+        }
+    }
+}
+
 unsafe impl<V: Visitor, T: TraceWith<V> + ?Sized> TraceWith<V> for RwLock<T> {
     #[inline]
     fn accept(&self, visitor: &mut V) -> Result<(), ()> {
@@ -138,12 +249,40 @@ unsafe impl<V: Visitor, T: TraceWith<V> + ?Sized> TraceWith<V> for RwLock<T> {
     }
 }
 
+impl<T: ContainsGcs> ContainsGcs for Option<T> {
+    #[inline]
+    fn contains_gcs(&self, visitor: &mut ContainsGcsVisitor) -> bool {
+        if visitor.consume_fuel().is_err() {
+            return true;
+        }
+
+        match self {
+            Some(x) => x.contains_gcs(visitor),
+            None => false,
+        }
+    }
+}
+
 unsafe impl<V: Visitor, T: TraceWith<V>> TraceWith<V> for Option<T> {
     #[inline]
     fn accept(&self, visitor: &mut V) -> Result<(), ()> {
         match self {
             Some(x) => x.accept(visitor),
             None => Ok(()),
+        }
+    }
+}
+
+impl<T: ContainsGcs, E: ContainsGcs> ContainsGcs for Result<T, E> {
+    #[inline]
+    fn contains_gcs(&self, visitor: &mut ContainsGcsVisitor) -> bool {
+        if visitor.consume_fuel().is_err() {
+            return true;
+        }
+
+        match self {
+            Ok(t) => t.contains_gcs(visitor),
+            Err(e) => e.contains_gcs(visitor),
         }
     }
 }
@@ -158,9 +297,26 @@ unsafe impl<V: Visitor, T: TraceWith<V>, E: TraceWith<V>> TraceWith<V> for Resul
     }
 }
 
+impl<T: ContainsGcs + Copy> ContainsGcs for Cell<T> {
+    fn contains_gcs(&self, visitor: &mut ContainsGcsVisitor) -> bool {
+        // we omit `visitor.consume_fuel()` since this directly accesses a single field
+        self.get().contains_gcs(visitor)
+    }
+}
+
 unsafe impl<V: Visitor, T: Copy + TraceWith<V>> TraceWith<V> for Cell<T> {
     fn accept(&self, visitor: &mut V) -> Result<(), ()> {
         self.get().accept(visitor)
+    }
+}
+
+impl<T: ContainsGcs> ContainsGcs for OnceCell<T> {
+    fn contains_gcs(&self, visitor: &mut ContainsGcsVisitor) -> bool {
+        if visitor.consume_fuel().is_err() {
+            return true;
+        }
+
+        self.get().map_or(false, |x| x.contains_gcs(visitor))
     }
 }
 
@@ -170,9 +326,26 @@ unsafe impl<V: Visitor, T: TraceWith<V>> TraceWith<V> for OnceCell<T> {
     }
 }
 
+impl<T: ContainsGcs> ContainsGcs for OnceLock<T> {
+    fn contains_gcs(&self, visitor: &mut ContainsGcsVisitor) -> bool {
+        if visitor.consume_fuel().is_err() {
+            return true;
+        }
+
+        self.get().map_or(false, |x| x.contains_gcs(visitor))
+    }
+}
+
 unsafe impl<V: Visitor, T: TraceWith<V>> TraceWith<V> for OnceLock<T> {
     fn accept(&self, visitor: &mut V) -> Result<(), ()> {
         self.get().map_or(Ok(()), |x| x.accept(visitor))
+    }
+}
+
+impl<T: ContainsGcs> ContainsGcs for std::cmp::Reverse<T> {
+    fn contains_gcs(&self, visitor: &mut ContainsGcsVisitor) -> bool {
+        // we omit `visitor.consume_fuel()` since this directly accesses a single field
+        self.0.contains_gcs(visitor)
     }
 }
 
@@ -182,9 +355,23 @@ unsafe impl<V: Visitor, T: TraceWith<V>> TraceWith<V> for std::cmp::Reverse<T> {
     }
 }
 
+impl<T: ContainsGcs + ?Sized> ContainsGcs for std::io::BufReader<T> {
+    fn contains_gcs(&self, visitor: &mut ContainsGcsVisitor) -> bool {
+        // we omit `visitor.consume_fuel()` since this directly accesses a single field
+        self.get_ref().contains_gcs(visitor)
+    }
+}
+
 unsafe impl<V: Visitor, T: TraceWith<V> + ?Sized> TraceWith<V> for std::io::BufReader<T> {
     fn accept(&self, visitor: &mut V) -> Result<(), ()> {
         self.get_ref().accept(visitor)
+    }
+}
+
+impl<T: ContainsGcs + std::io::Write + ?Sized> ContainsGcs for std::io::BufWriter<T> {
+    fn contains_gcs(&self, visitor: &mut ContainsGcsVisitor) -> bool {
+        // we omit `visitor.consume_fuel()` since this directly accesses a single field
+        self.get_ref().contains_gcs(visitor)
     }
 }
 
@@ -196,6 +383,14 @@ unsafe impl<V: Visitor, T: TraceWith<V> + std::io::Write + ?Sized> TraceWith<V>
     }
 }
 
+impl<T: ContainsGcs, U: ContainsGcs> ContainsGcs for std::io::Chain<T, U> {
+    fn contains_gcs(&self, visitor: &mut ContainsGcsVisitor) -> bool {
+        // we omit `visitor.consume_fuel()` since this directly accesses a single field
+        let (t, u) = self.get_ref();
+        t.contains_gcs(visitor) || u.contains_gcs(visitor)
+    }
+}
+
 unsafe impl<V: Visitor, T: TraceWith<V>, U: TraceWith<V>> TraceWith<V> for std::io::Chain<T, U> {
     fn accept(&self, visitor: &mut V) -> Result<(), ()> {
         let (t, u) = self.get_ref();
@@ -204,9 +399,23 @@ unsafe impl<V: Visitor, T: TraceWith<V>, U: TraceWith<V>> TraceWith<V> for std::
     }
 }
 
+impl<T: ContainsGcs> ContainsGcs for std::io::Cursor<T> {
+    fn contains_gcs(&self, visitor: &mut ContainsGcsVisitor) -> bool {
+        // we omit `visitor.consume_fuel()` since this directly accesses a single field
+        self.get_ref().contains_gcs(visitor)
+    }
+}
+
 unsafe impl<V: Visitor, T: TraceWith<V>> TraceWith<V> for std::io::Cursor<T> {
     fn accept(&self, visitor: &mut V) -> Result<(), ()> {
         self.get_ref().accept(visitor)
+    }
+}
+
+impl<T: ContainsGcs + std::io::Write + ?Sized> ContainsGcs for std::io::LineWriter<T> {
+    fn contains_gcs(&self, visitor: &mut ContainsGcsVisitor) -> bool {
+        // we omit `visitor.consume_fuel()` since this directly accesses a single field
+        self.get_ref().contains_gcs(visitor)
     }
 }
 
@@ -218,9 +427,23 @@ unsafe impl<V: Visitor, T: TraceWith<V> + std::io::Write + ?Sized> TraceWith<V>
     }
 }
 
+impl<T: ContainsGcs> ContainsGcs for std::io::Take<T> {
+    fn contains_gcs(&self, visitor: &mut ContainsGcsVisitor) -> bool {
+        // we omit `visitor.consume_fuel()` since this directly accesses a single field
+        self.get_ref().contains_gcs(visitor)
+    }
+}
+
 unsafe impl<V: Visitor, T: TraceWith<V>> TraceWith<V> for std::io::Take<T> {
     fn accept(&self, visitor: &mut V) -> Result<(), ()> {
         self.get_ref().accept(visitor)
+    }
+}
+
+impl<T: ContainsGcs> ContainsGcs for std::mem::ManuallyDrop<T> {
+    fn contains_gcs(&self, visitor: &mut ContainsGcsVisitor) -> bool {
+        // we omit `visitor.consume_fuel()` since this directly accesses a single field
+        (**self).contains_gcs(visitor)
     }
 }
 
@@ -230,15 +453,39 @@ unsafe impl<V: Visitor, T: TraceWith<V>> TraceWith<V> for std::mem::ManuallyDrop
     }
 }
 
+impl<T: ContainsGcs> ContainsGcs for std::num::Saturating<T> {
+    fn contains_gcs(&self, visitor: &mut ContainsGcsVisitor) -> bool {
+        // we omit `visitor.consume_fuel()` since this directly accesses a single field
+        self.0.contains_gcs(visitor)
+    }
+}
+
 unsafe impl<V: Visitor, T: TraceWith<V>> TraceWith<V> for std::num::Saturating<T> {
     fn accept(&self, visitor: &mut V) -> Result<(), ()> {
         self.0.accept(visitor)
     }
 }
 
+impl<T: ContainsGcs> ContainsGcs for std::num::Wrapping<T> {
+    fn contains_gcs(&self, visitor: &mut ContainsGcsVisitor) -> bool {
+        // we omit `visitor.consume_fuel()` since this directly accesses a single field
+        self.0.contains_gcs(visitor)
+    }
+}
+
 unsafe impl<V: Visitor, T: TraceWith<V>> TraceWith<V> for std::num::Wrapping<T> {
     fn accept(&self, visitor: &mut V) -> Result<(), ()> {
         self.0.accept(visitor)
+    }
+}
+
+impl<T: ContainsGcs> ContainsGcs for std::ops::Range<T> {
+    fn contains_gcs(&self, visitor: &mut ContainsGcsVisitor) -> bool {
+        if visitor.consume_fuel().is_err() {
+            return true;
+        }
+
+        self.start.contains_gcs(visitor) || self.end.contains_gcs(visitor)
     }
 }
 
@@ -249,9 +496,26 @@ unsafe impl<V: Visitor, T: TraceWith<V>> TraceWith<V> for std::ops::Range<T> {
     }
 }
 
+impl<T: ContainsGcs> ContainsGcs for std::ops::RangeFrom<T> {
+    fn contains_gcs(&self, visitor: &mut ContainsGcsVisitor) -> bool {
+        // we omit `visitor.consume_fuel()` since this directly accesses a single field
+        self.start.contains_gcs(visitor)
+    }
+}
+
 unsafe impl<V: Visitor, T: TraceWith<V>> TraceWith<V> for std::ops::RangeFrom<T> {
     fn accept(&self, visitor: &mut V) -> Result<(), ()> {
         self.start.accept(visitor)
+    }
+}
+
+impl<T: ContainsGcs> ContainsGcs for std::ops::RangeInclusive<T> {
+    fn contains_gcs(&self, visitor: &mut ContainsGcsVisitor) -> bool {
+        if visitor.consume_fuel().is_err() {
+            return true;
+        }
+
+        self.start().contains_gcs(visitor) || self.end().contains_gcs(visitor)
     }
 }
 
@@ -262,9 +526,23 @@ unsafe impl<V: Visitor, T: TraceWith<V>> TraceWith<V> for std::ops::RangeInclusi
     }
 }
 
+impl<T: ContainsGcs> ContainsGcs for std::ops::RangeTo<T> {
+    fn contains_gcs(&self, visitor: &mut ContainsGcsVisitor) -> bool {
+        // we omit `visitor.consume_fuel()` since this directly accesses a single field
+        self.end.contains_gcs(visitor)
+    }
+}
+
 unsafe impl<V: Visitor, T: TraceWith<V>> TraceWith<V> for std::ops::RangeTo<T> {
     fn accept(&self, visitor: &mut V) -> Result<(), ()> {
         self.end.accept(visitor)
+    }
+}
+
+impl<T: ContainsGcs> ContainsGcs for std::ops::RangeToInclusive<T> {
+    fn contains_gcs(&self, visitor: &mut ContainsGcsVisitor) -> bool {
+        // we omit `visitor.consume_fuel()` since this directly accesses a single field
+        self.end.contains_gcs(visitor)
     }
 }
 
@@ -274,11 +552,37 @@ unsafe impl<V: Visitor, T: TraceWith<V>> TraceWith<V> for std::ops::RangeToInclu
     }
 }
 
+impl<T: ContainsGcs> ContainsGcs for std::ops::Bound<T> {
+    fn contains_gcs(&self, visitor: &mut ContainsGcsVisitor) -> bool {
+        if visitor.consume_fuel().is_err() {
+            return true;
+        }
+
+        match self {
+            std::ops::Bound::Included(x) | std::ops::Bound::Excluded(x) => x.contains_gcs(visitor),
+            std::ops::Bound::Unbounded => false,
+        }
+    }
+}
+
 unsafe impl<V: Visitor, T: TraceWith<V>> TraceWith<V> for std::ops::Bound<T> {
     fn accept(&self, visitor: &mut V) -> Result<(), ()> {
         match self {
             std::ops::Bound::Included(x) | std::ops::Bound::Excluded(x) => x.accept(visitor),
             std::ops::Bound::Unbounded => Ok(()),
+        }
+    }
+}
+
+impl<B: ContainsGcs, C: ContainsGcs> ContainsGcs for std::ops::ControlFlow<B, C> {
+    fn contains_gcs(&self, visitor: &mut ContainsGcsVisitor) -> bool {
+        if visitor.consume_fuel().is_err() {
+            return true;
+        }
+
+        match self {
+            std::ops::ControlFlow::Continue(c) => c.contains_gcs(visitor),
+            std::ops::ControlFlow::Break(b) => b.contains_gcs(visitor),
         }
     }
 }
@@ -294,9 +598,29 @@ unsafe impl<V: Visitor, B: TraceWith<V>, C: TraceWith<V>> TraceWith<V>
     }
 }
 
+impl<T: ContainsGcs> ContainsGcs for std::panic::AssertUnwindSafe<T> {
+    fn contains_gcs(&self, visitor: &mut ContainsGcsVisitor) -> bool {
+        // we omit `visitor.consume_fuel()` since this directly accesses a single field
+        self.0.contains_gcs(visitor)
+    }
+}
+
 unsafe impl<V: Visitor, T: TraceWith<V>> TraceWith<V> for std::panic::AssertUnwindSafe<T> {
     fn accept(&self, visitor: &mut V) -> Result<(), ()> {
         self.0.accept(visitor)
+    }
+}
+
+impl<T: ContainsGcs> ContainsGcs for std::task::Poll<T> {
+    fn contains_gcs(&self, visitor: &mut ContainsGcsVisitor) -> bool {
+        if visitor.consume_fuel().is_err() {
+            return true;
+        }
+
+        match self {
+            std::task::Poll::Ready(r) => r.contains_gcs(visitor),
+            std::task::Poll::Pending => false,
+        }
     }
 }
 
@@ -314,6 +638,22 @@ unsafe impl<V: Visitor, T: TraceWith<V>> TraceWith<V> for std::task::Poll<T> {
 /// mutable references.
 macro_rules! Trace_collection_impl {
     ($x: ty) => {
+        impl<T: ContainsGcs> ContainsGcs for $x {
+            fn contains_gcs(&self, visitor: &mut ContainsGcsVisitor) -> bool {
+                if visitor.consume_fuel().is_err() {
+                    return true;
+                }
+
+                for elem in self {
+                    if elem.contains_gcs(visitor) {
+                        return true;
+                    }
+                }
+
+                false
+            }
+        }
+
         unsafe impl<V: Visitor, T: TraceWith<V>> TraceWith<V> for $x {
             #[inline]
             fn accept(&self, visitor: &mut V) -> Result<(), ()> {
@@ -333,6 +673,22 @@ Trace_collection_impl!([T]);
 Trace_collection_impl!(BinaryHeap<T>);
 Trace_collection_impl!(BTreeSet<T>);
 
+impl<T: ContainsGcs> ContainsGcs for std::vec::IntoIter<T> {
+    fn contains_gcs(&self, visitor: &mut ContainsGcsVisitor) -> bool {
+        if visitor.consume_fuel().is_err() {
+            return true;
+        }
+
+        for elem in self.as_slice() {
+            if elem.contains_gcs(visitor) {
+                return true;
+            }
+        }
+
+        false
+    }
+}
+
 unsafe impl<V: Visitor, T: TraceWith<V>> TraceWith<V> for std::vec::IntoIter<T> {
     #[inline]
     fn accept(&self, visitor: &mut V) -> Result<(), ()> {
@@ -340,6 +696,24 @@ unsafe impl<V: Visitor, T: TraceWith<V>> TraceWith<V> for std::vec::IntoIter<T> 
             elem.accept(visitor)?;
         }
         Ok(())
+    }
+}
+
+impl<K: ContainsGcs, V: ContainsGcs, S: ContainsGcs + BuildHasher> ContainsGcs
+    for HashMap<K, V, S>
+{
+    fn contains_gcs(&self, visitor: &mut ContainsGcsVisitor) -> bool {
+        if visitor.consume_fuel().is_err() {
+            return true;
+        }
+
+        for (k, v) in self {
+            if k.contains_gcs(visitor) || v.contains_gcs(visitor) {
+                return true;
+            }
+        }
+
+        self.hasher().contains_gcs(visitor)
     }
 }
 
@@ -355,6 +729,22 @@ unsafe impl<Z: Visitor, K: TraceWith<Z>, V: TraceWith<Z>, S: BuildHasher + Trace
     }
 }
 
+impl<T: ContainsGcs, S: ContainsGcs + BuildHasher> ContainsGcs for HashSet<T, S> {
+    fn contains_gcs(&self, visitor: &mut ContainsGcsVisitor) -> bool {
+        if visitor.consume_fuel().is_err() {
+            return true;
+        }
+
+        for elem in self {
+            if elem.contains_gcs(visitor) {
+                return true;
+            }
+        }
+
+        self.hasher().contains_gcs(visitor)
+    }
+}
+
 unsafe impl<Z: Visitor, T: TraceWith<Z>, S: BuildHasher + TraceWith<Z>> TraceWith<Z>
     for HashSet<T, S>
 {
@@ -366,6 +756,22 @@ unsafe impl<Z: Visitor, T: TraceWith<Z>, S: BuildHasher + TraceWith<Z>> TraceWit
     }
 }
 
+impl<K: ContainsGcs, V: ContainsGcs> ContainsGcs for BTreeMap<K, V> {
+    fn contains_gcs(&self, visitor: &mut ContainsGcsVisitor) -> bool {
+        if visitor.consume_fuel().is_err() {
+            return true;
+        }
+
+        for (k, v) in self {
+            if k.contains_gcs(visitor) || v.contains_gcs(visitor) {
+                return true;
+            }
+        }
+
+        false
+    }
+}
+
 unsafe impl<Z: Visitor, K: TraceWith<Z>, V: TraceWith<Z>> TraceWith<Z> for BTreeMap<K, V> {
     fn accept(&self, visitor: &mut Z) -> Result<(), ()> {
         for (k, v) in self {
@@ -373,6 +779,23 @@ unsafe impl<Z: Visitor, K: TraceWith<Z>, V: TraceWith<Z>> TraceWith<Z> for BTree
             v.accept(visitor)?;
         }
         Ok(())
+    }
+}
+
+impl<T: ContainsGcs, const N: usize> ContainsGcs for [T; N] {
+    #[inline]
+    fn contains_gcs(&self, visitor: &mut ContainsGcsVisitor) -> bool {
+        if visitor.consume_fuel().is_err() {
+            return true;
+        }
+
+        for elem in self.as_slice() {
+            if elem.contains_gcs(visitor) {
+                return true;
+            }
+        }
+
+        false
     }
 }
 
@@ -390,6 +813,13 @@ unsafe impl<V: Visitor, T: TraceWith<V>, const N: usize> TraceWith<V> for [T; N]
 /// fields.
 macro_rules! Trace_trivial_impl {
     ($x: ty) => {
+        impl ContainsGcs for $x {
+            #[inline]
+            fn contains_gcs(&self, _: &mut ContainsGcsVisitor) -> bool {
+                false
+            }
+        }
+
         unsafe impl<V: Visitor> TraceWith<V> for $x {
             #[inline]
             fn accept(&self, _: &mut V) -> Result<(), ()> {
@@ -572,6 +1002,23 @@ Trace_trivial_impl!(std::time::TryFromFloatSecsError);
 macro_rules! Trace_tuple {
     () => {}; // This case is handled above by the trivial case
     ($($args:ident),*) => {
+        impl<$($args: ContainsGcs),*> ContainsGcs for ($($args,)*) {
+            fn contains_gcs(&self, visitor: &mut ContainsGcsVisitor) -> bool {
+                if visitor.consume_fuel().is_err() {
+                    return true;
+                }
+                #[expect(clippy::allow_attributes)]
+                #[allow(non_snake_case)]
+                let &($(ref $args,)*) = self;
+                $(
+                    if ($args).contains_gcs(visitor) {
+                        return true;
+                    }
+                )*
+                false
+            }
+        }
+
         unsafe impl<V: Visitor, $($args: TraceWith<V>),*> TraceWith<V> for ($($args,)*) {
             fn accept(&self, visitor: &mut V) -> Result<(), ()> {
                 #[expect(clippy::allow_attributes)]
@@ -599,6 +1046,12 @@ Trace_tuple!(A, B, C, D, E, F, G, H, I, J);
 /// Implement `TraceWith<V>` for one function type.
 macro_rules! Trace_fn {
     ($ty:ty $(,$args:ident)*) => {
+        impl<Ret $(,$args)*> ContainsGcs for $ty {
+            fn contains_gcs(&self, _: &mut ContainsGcsVisitor) -> bool {
+                false
+            }
+        }
+
         unsafe impl<V: Visitor, Ret $(,$args)*> TraceWith<V> for $ty {
             fn accept(&self, _: &mut V) -> Result<(), ()> { Ok(()) }
         }

--- a/dumpster/src/lib.rs
+++ b/dumpster/src/lib.rs
@@ -203,16 +203,16 @@ pub mod unsync;
 
 /// Contains the sealed trait for [`Trace`].
 mod trace {
-    use crate::{sync::TraceSync, unsync::TraceUnsync, ContainsGcs, TraceWith};
+    use crate::{sync::TraceSync, unsync::TraceUnsync, ContainsGcs};
 
     /// The sealed trait for [`Trace`](crate::Trace),
     /// hiding away the implementation details and making it
     /// impossible to manually implement `Trace`.
     #[expect(clippy::missing_safety_doc)]
     #[expect(private_bounds)]
-    pub unsafe trait TraceWithV: TraceWith<ContainsGcs> + TraceSync + TraceUnsync {}
+    pub unsafe trait TraceWithV: ContainsGcs + TraceSync + TraceUnsync {}
 
-    unsafe impl<T> TraceWithV for T where T: ?Sized + TraceWith<ContainsGcs> + TraceSync + TraceUnsync {}
+    unsafe impl<T> TraceWithV for T where T: ?Sized + ContainsGcs + TraceSync + TraceUnsync {}
 }
 
 /// The trait that any garbage-collected data must implement.
@@ -232,9 +232,15 @@ mod trace {
 /// Accepting a visitor is simply a no-op.
 ///
 /// ```
-/// use dumpster::{TraceWith, Visitor};
+/// use dumpster::{TraceWith, Visitor, ContainsGcs, ContainsGcsVisitor};
 ///
 /// struct Foo(u8);
+///
+/// impl ContainsGcs for Foo {
+///     fn contains_gcs(&self, visitor: &mut ContainsGcsVisitor) -> bool {
+///         false
+///     }
+/// }
 ///
 /// unsafe impl<V: Visitor> TraceWith<V> for Foo {
 ///     fn accept(&self, visitor: &mut V) -> Result<(), ()> {
@@ -247,9 +253,15 @@ mod trace {
 /// fields in `accept`.
 ///
 /// ```
-/// use dumpster::{unsync::Gc, TraceWith, Visitor};
+/// use dumpster::{unsync::Gc, TraceWith, Visitor, ContainsGcs, ContainsGcsVisitor};
 ///
 /// struct Bar(Gc<Bar>);
+///
+/// impl ContainsGcs for Bar {
+///     fn contains_gcs(&self, visitor: &mut ContainsGcsVisitor) -> bool {
+///         self.0.contains_gcs(visitor)
+///     }
+/// }
 ///
 /// unsafe impl<V: Visitor> TraceWith<V> for Bar {
 ///     fn accept(&self, visitor: &mut V) -> Result<(), ()> {
@@ -262,11 +274,21 @@ mod trace {
 /// delegate to both fields in a consistent order:
 ///
 /// ```
-/// use dumpster::{unsync::Gc, TraceWith, Visitor};
+/// use dumpster::{unsync::Gc, TraceWith, Visitor, ContainsGcs, ContainsGcsVisitor};
 ///
 /// struct Baz {
 ///     a: Gc<Baz>,
 ///     b: Gc<Baz>,
+/// }
+///
+/// impl ContainsGcs for Baz {
+///     fn contains_gcs(&self, visitor: &mut ContainsGcsVisitor) -> bool {
+///         if visitor.consume_fuel().is_err() {
+///             return true;
+///         }
+///
+///         self.a.contains_gcs(visitor) || self.b.contains_gcs(visitor)
+///     }
 /// }
 ///
 /// unsafe impl<V: Visitor> TraceWith<V> for Baz {
@@ -407,36 +429,74 @@ extern crate dumpster_derive;
 /// ```
 pub use dumpster_derive::Trace;
 
-/// Determine whether some value contains a garbage-collected pointer.
-///
-/// This function will return one of three values:
-/// - `Ok(true)`: The data structure contains a garbage-collected pointer.
-/// - `Ok(false)`: The data structure contains no garbage-collected pointers.
-/// - `Err(())`: The data structure was accessed while we checked it for garbage-collected pointers.
-fn contains_gcs<T: Trace + ?Sized>(x: &T) -> Result<bool, ()> {
-    let mut visit = ContainsGcs(false);
-    x.accept(&mut visit)?;
-    Ok(visit.0)
+/// Determines whether some value contains a garbage-collected pointer.
+fn contains_gcs<T: Trace + ?Sized>(x: &T) -> bool {
+    let mut visitor = ContainsGcsVisitor { fuel: 64 };
+    x.contains_gcs(&mut visitor)
 }
 
-/// A visitor structure used for determining whether some garbage-collected pointer contains a
-/// `Gc` in its pointed-to value.
-struct ContainsGcs(bool);
+/// A visitor for the [`ContainsGcs`] trait.
+pub struct ContainsGcsVisitor {
+    fuel: usize,
+}
 
-impl Visitor for ContainsGcs {
-    fn visit_sync<T>(&mut self, _: &sync::Gc<T>)
-    where
-        T: Trace + Send + Sync + ?Sized,
-    {
-        self.0 = true;
+impl ContainsGcsVisitor {
+    /// Consumes the visitors fuel.
+    ///
+    /// This should generally be called first in [`contains_gcs`] implementations and
+    /// the function should return early with `true` when the visitor is out of fuel.
+    ///
+    /// # Errors
+    ///
+    /// Errors if the visitor is out of fuel.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dumpster::{unsync::Gc, ContainsGcs, ContainsGcsVisitor, TraceWith, Visitor};
+    ///
+    /// struct Foo {
+    ///     a: Gc<Foo>,
+    ///     b: Gc<Foo>,
+    /// }
+    ///
+    /// impl ContainsGcs for Foo {
+    ///     fn contains_gcs(&self, visitor: &mut ContainsGcsVisitor) -> bool {
+    ///         if visitor.consume_fuel().is_err() {
+    ///             return true;
+    ///         }
+    ///
+    ///         self.a.contains_gcs(visitor) || self.b.contains_gcs(visitor)
+    ///     }
+    /// }
+    ///
+    /// unsafe impl<V: Visitor> TraceWith<V> for Foo {
+    ///     fn accept(&self, visitor: &mut V) -> Result<(), ()> {
+    ///         self.a.accept(visitor)?;
+    ///         self.b.accept(visitor)?;
+    ///         Ok(())
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// [`contains_gcs`]: ContainsGcs::contains_gcs
+    pub fn consume_fuel(&mut self) -> Result<(), ()> {
+        self.fuel = self.fuel.checked_sub(1).ok_or(())?;
+        Ok(())
     }
+}
 
-    fn visit_unsync<T>(&mut self, _: &unsync::Gc<T>)
-    where
-        T: Trace + ?Sized,
-    {
-        self.0 = true;
-    }
+/// A trait informing whether the data contains garbage-collected pointers
+///
+/// Returning `true` from the `contains_gcs` function is always valid.
+///
+/// When this data structure doesn't contain any garbage-collected pointers then
+/// `contains_gcs` may return `false`. This can improve performance because those
+/// data structures then don't have to be traced to be garbage collected.
+pub trait ContainsGcs {
+    /// This funtion returns `true` when this data structure may contain garbage-collected pointers
+    /// and `false` when it definitely does not.
+    fn contains_gcs(&self, visitor: &mut ContainsGcsVisitor) -> bool;
 }
 
 /// Panics with a message that explains that the gc object has already been collected.

--- a/dumpster/src/sync/mod.rs
+++ b/dumpster/src/sync/mod.rs
@@ -41,14 +41,13 @@ use loom::{
     lazy_static,
     sync::atomic::{fence, AtomicUsize, Ordering},
 };
-use std::fmt::Display;
 #[cfg(not(loom))]
 use std::sync::atomic::{fence, AtomicUsize, Ordering};
 use std::{
     alloc::{dealloc, handle_alloc_error, Layout},
     any::TypeId,
     borrow::{Borrow, Cow},
-    fmt::Debug,
+    fmt::{Debug, Display},
     mem::{self, ManuallyDrop, MaybeUninit},
     num::NonZeroUsize,
     ops::Deref,

--- a/dumpster/src/sync/mod.rs
+++ b/dumpster/src/sync/mod.rs
@@ -62,7 +62,7 @@ use crate::{
         cell::UCell,
         collect::{Dfs, PrepareForDestruction},
     },
-    Trace, TraceWith, Visitor,
+    ContainsGcs, ContainsGcsVisitor, Trace, TraceWith, Visitor,
 };
 
 use self::collect::{
@@ -338,6 +338,12 @@ where
         /// May only be used inside `new_cyclic`.
         #[repr(transparent)]
         struct Uninitialized<T>(MaybeUninit<T>);
+
+        impl<T> ContainsGcs for Uninitialized<T> {
+            fn contains_gcs(&self, _: &mut ContainsGcsVisitor) -> bool {
+                false
+            }
+        }
 
         unsafe impl<V: Visitor, T> TraceWith<V> for Uninitialized<T> {
             fn accept(&self, _: &mut V) -> Result<(), ()> {
@@ -913,7 +919,7 @@ where
                 }
             }
             _ => {
-                if contains_gcs(&box_ref.value).unwrap_or(true) {
+                if contains_gcs(&box_ref.value) {
                     // SAFETY: `ptr` is convertible to a reference
                     // We don't use `box_ref` here because that pointer
                     // only has `SharedReadOnly` permissions under the stacked borrows model
@@ -1022,6 +1028,12 @@ impl<T: Trace + Send + Sync> Gc<[T]> {
                 ptr::slice_from_raw_parts_mut(mem.cast::<T>(), len) as *mut GcBox<[T]>
             })
         }
+    }
+}
+
+impl<T: Trace + Send + Sync + ?Sized> ContainsGcs for Gc<T> {
+    fn contains_gcs(&self, _: &mut ContainsGcsVisitor) -> bool {
+        true
     }
 }
 

--- a/dumpster/src/sync/tests.rs
+++ b/dumpster/src/sync/tests.rs
@@ -30,6 +30,12 @@ impl Drop for DropCount<'_> {
     }
 }
 
+impl ContainsGcs for DropCount<'_> {
+    fn contains_gcs(&self, _: &mut ContainsGcsVisitor) -> bool {
+        false
+    }
+}
+
 unsafe impl<V: Visitor> TraceWith<V> for DropCount<'_> {
     fn accept(&self, _: &mut V) -> Result<(), ()> {
         Ok(())
@@ -40,6 +46,16 @@ struct MultiRef {
     refs: Mutex<Vec<Gc<MultiRef>>>,
     #[expect(unused)]
     count: DropCount<'static>,
+}
+
+impl ContainsGcs for MultiRef {
+    fn contains_gcs(&self, visitor: &mut ContainsGcsVisitor) -> bool {
+        if visitor.consume_fuel().is_err() {
+            return true;
+        }
+
+        self.refs.contains_gcs(visitor)
+    }
 }
 
 unsafe impl<V: Visitor> TraceWith<V> for MultiRef {
@@ -77,6 +93,16 @@ fn ref_count() {
 fn self_referential() {
     struct Foo(Mutex<Option<Gc<Foo>>>);
     static DROP_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+    impl ContainsGcs for Foo {
+        fn contains_gcs(&self, visitor: &mut ContainsGcsVisitor) -> bool {
+            if visitor.consume_fuel().is_err() {
+                return true;
+            }
+
+            self.0.contains_gcs(visitor)
+        }
+    }
 
     unsafe impl<V: Visitor> TraceWith<V> for Foo {
         fn accept(&self, visitor: &mut V) -> Result<(), ()> {
@@ -317,10 +343,27 @@ fn malicious() {
 
     unsafe impl Send for X {}
 
+    impl ContainsGcs for A {
+        fn contains_gcs(&self, visitor: &mut ContainsGcsVisitor) -> bool {
+            if visitor.consume_fuel().is_err() {
+                return true;
+            }
+
+            self.x.contains_gcs(visitor) || self.y.contains_gcs(visitor)
+        }
+    }
+
     unsafe impl<V: Visitor> TraceWith<V> for A {
         fn accept(&self, visitor: &mut V) -> Result<(), ()> {
             self.x.accept(visitor)?;
             self.y.accept(visitor)
+        }
+    }
+
+    impl ContainsGcs for X {
+        fn contains_gcs(&self, _: &mut ContainsGcsVisitor) -> bool {
+            // contains gcs optimization doesn't matter here
+            true
         }
     }
 
@@ -336,6 +379,16 @@ fn malicious() {
             }
 
             Ok(())
+        }
+    }
+
+    impl ContainsGcs for Y {
+        fn contains_gcs(&self, visitor: &mut ContainsGcsVisitor) -> bool {
+            if visitor.consume_fuel().is_err() {
+                return true;
+            }
+
+            self.a.contains_gcs(visitor)
         }
     }
 
@@ -400,6 +453,16 @@ fn fuzz() {
     impl Drop for Alloc {
         fn drop(&mut self) {
             DROP_DETECTORS[self.id].fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    impl ContainsGcs for Alloc {
+        fn contains_gcs(&self, visitor: &mut ContainsGcsVisitor) -> bool {
+            if visitor.consume_fuel().is_err() {
+                return true;
+            }
+
+            self.refs.contains_gcs(visitor)
         }
     }
 
@@ -513,9 +576,26 @@ fn root_canal() {
         a3: Mutex<Option<Gc<A>>>,
     }
 
+    impl ContainsGcs for A {
+        fn contains_gcs(&self, visitor: &mut ContainsGcsVisitor) -> bool {
+            if visitor.consume_fuel().is_err() {
+                return true;
+            }
+
+            self.b.contains_gcs(visitor)
+        }
+    }
+
     unsafe impl<V: Visitor> TraceWith<V> for A {
         fn accept(&self, visitor: &mut V) -> Result<(), ()> {
             self.b.accept(visitor)
+        }
+    }
+
+    impl ContainsGcs for B {
+        fn contains_gcs(&self, _: &mut ContainsGcsVisitor) -> bool {
+            // contains gcs optimization doesn't matter here
+            true
         }
     }
 
@@ -635,6 +715,16 @@ fn escape_dead_pointer() {
         }
     }
 
+    impl ContainsGcs for Escape {
+        fn contains_gcs(&self, visitor: &mut ContainsGcsVisitor) -> bool {
+            if visitor.consume_fuel().is_err() {
+                return true;
+            }
+
+            self.ptr.contains_gcs(visitor)
+        }
+    }
+
     unsafe impl<V: Visitor> TraceWith<V> for Escape {
         fn accept(&self, visitor: &mut V) -> Result<(), ()> {
             self.ptr.accept(visitor)
@@ -702,6 +792,12 @@ fn from_slice_panic() {
                 value: self.value.clone(),
                 panic: self.panic,
             }
+        }
+    }
+
+    impl ContainsGcs for MayPanicOnClone {
+        fn contains_gcs(&self, _: &mut ContainsGcsVisitor) -> bool {
+            false
         }
     }
 
@@ -801,6 +897,16 @@ fn make_mut_of_object_in_dumpster() {
         something: Gc<i32>,
     }
 
+    impl ContainsGcs for Foo {
+        fn contains_gcs(&self, visitor: &mut ContainsGcsVisitor) -> bool {
+            if visitor.consume_fuel().is_err() {
+                return true;
+            }
+
+            self.something.contains_gcs(visitor)
+        }
+    }
+
     unsafe impl<V: Visitor> TraceWith<V> for Foo {
         fn accept(&self, visitor: &mut V) -> Result<(), ()> {
             self.something.accept(visitor)
@@ -835,6 +941,12 @@ fn make_mut_of_object_in_dumpster() {
 fn panic_visit() {
     struct PanicVisit;
 
+    impl ContainsGcs for PanicVisit {
+        fn contains_gcs(&self, _: &mut ContainsGcsVisitor) -> bool {
+            panic!("panic on visit");
+        }
+    }
+
     /// We technically can make it part of the contract for `Trace` to reject panicking impls,
     /// but it is good form to accept these even though they are malformed.
     unsafe impl<V: Visitor> TraceWith<V> for PanicVisit {
@@ -856,9 +968,29 @@ fn sync_leak_by_creation_in_drop() {
     struct Foo(OnceLock<Gc<Self>>);
     struct Bar(OnceLock<Gc<Self>>);
 
+    impl ContainsGcs for Foo {
+        fn contains_gcs(&self, visitor: &mut ContainsGcsVisitor) -> bool {
+            if visitor.consume_fuel().is_err() {
+                return true;
+            }
+
+            self.0.contains_gcs(visitor)
+        }
+    }
+
     unsafe impl<V: Visitor> TraceWith<V> for Foo {
         fn accept(&self, visitor: &mut V) -> Result<(), ()> {
             self.0.accept(visitor)
+        }
+    }
+
+    impl ContainsGcs for Bar {
+        fn contains_gcs(&self, visitor: &mut ContainsGcsVisitor) -> bool {
+            if visitor.consume_fuel().is_err() {
+                return true;
+            }
+
+            self.0.contains_gcs(visitor)
         }
     }
 
@@ -909,6 +1041,15 @@ fn custom_trait_object() {
 #[test]
 fn new_cyclic_simple() {
     struct Cycle(Gc<Self>);
+    impl ContainsGcs for Cycle {
+        fn contains_gcs(&self, visitor: &mut ContainsGcsVisitor) -> bool {
+            if visitor.consume_fuel().is_err() {
+                return true;
+            }
+
+            self.0.contains_gcs(visitor)
+        }
+    }
     unsafe impl<V: Visitor> TraceWith<V> for Cycle {
         fn accept(&self, visitor: &mut V) -> Result<(), ()> {
             self.0.accept(visitor)
@@ -935,6 +1076,16 @@ fn self_referential_from_iter() {
     struct Ab {
         a: Gc<Self>,
         b: Gc<Self>,
+    }
+
+    impl ContainsGcs for Ab {
+        fn contains_gcs(&self, visitor: &mut ContainsGcsVisitor) -> bool {
+            if visitor.consume_fuel().is_err() {
+                return true;
+            }
+
+            self.a.contains_gcs(visitor) || self.b.contains_gcs(visitor)
+        }
     }
 
     unsafe impl<V: Visitor> TraceWith<V> for Ab {

--- a/dumpster/src/unsync/mod.rs
+++ b/dumpster/src/unsync/mod.rs
@@ -33,7 +33,8 @@
 //! ```
 
 use crate::{
-    contains_gcs, panic_deref_of_collected_object, ptr::Nullable, Trace, TraceWith, Visitor,
+    contains_gcs, panic_deref_of_collected_object, ptr::Nullable, ContainsGcs, ContainsGcsVisitor,
+    Trace, TraceWith, Visitor,
 };
 use std::{
     alloc::{dealloc, handle_alloc_error, Layout},
@@ -287,6 +288,12 @@ impl<T: Trace + ?Sized> Gc<T> {
         /// May only be used inside `new_cyclic`.
         #[repr(transparent)]
         struct Uninitialized<T>(MaybeUninit<T>);
+
+        impl<T> ContainsGcs for Uninitialized<T> {
+            fn contains_gcs(&self, _: &mut ContainsGcsVisitor) -> bool {
+                false
+            }
+        }
 
         unsafe impl<V: Visitor, T> TraceWith<V> for Uninitialized<T> {
             fn accept(&self, _: &mut V) -> Result<(), ()> {
@@ -933,7 +940,7 @@ impl<T: Trace + ?Sized> Drop for Gc<T> {
                             .ref_count
                             .set(NonZeroUsize::new(n.get() - 1).unwrap());
 
-                        if contains_gcs(&box_ref.value).unwrap_or(true) {
+                        if contains_gcs(&box_ref.value) {
                             // remaining references could be a cycle - therefore, mark it as dirty
                             // so we can check later
                             d.mark_dirty(ptr);
@@ -1048,6 +1055,12 @@ impl CollectInfo {
     /// ```
     pub fn n_gcs_existing(&self) -> usize {
         DUMPSTER.try_with(|d| d.n_refs_living.get()).unwrap_or(0)
+    }
+}
+
+impl<T: Trace + ?Sized> ContainsGcs for Gc<T> {
+    fn contains_gcs(&self, _: &mut ContainsGcsVisitor) -> bool {
+        true
     }
 }
 

--- a/dumpster/src/unsync/tests.rs
+++ b/dumpster/src/unsync/tests.rs
@@ -31,6 +31,12 @@ impl Drop for DropCount {
     }
 }
 
+impl ContainsGcs for DropCount {
+    fn contains_gcs(&self, _: &mut ContainsGcsVisitor) -> bool {
+        false
+    }
+}
+
 unsafe impl<V: Visitor> TraceWith<V> for DropCount {
     fn accept(&self, _: &mut V) -> Result<(), ()> {
         Ok(())
@@ -46,6 +52,12 @@ fn simple() {
     impl Drop for Foo {
         fn drop(&mut self) {
             DROPPED.store(true, Ordering::Relaxed);
+        }
+    }
+
+    impl ContainsGcs for Foo {
+        fn contains_gcs(&self, _: &mut ContainsGcsVisitor) -> bool {
+            false
         }
     }
 
@@ -75,6 +87,16 @@ struct MultiRef {
     drop_count: &'static AtomicUsize,
 }
 
+impl ContainsGcs for MultiRef {
+    fn contains_gcs(&self, visitor: &mut ContainsGcsVisitor) -> bool {
+        if visitor.consume_fuel().is_err() {
+            return true;
+        }
+
+        self.refs.contains_gcs(visitor)
+    }
+}
+
 unsafe impl<V: Visitor> TraceWith<V> for MultiRef {
     fn accept(&self, visitor: &mut V) -> Result<(), ()> {
         self.refs.accept(visitor)
@@ -91,6 +113,16 @@ impl Drop for MultiRef {
 fn self_referential() {
     static DROPPED: AtomicU8 = AtomicU8::new(0);
     struct Foo(RefCell<Option<Gc<Foo>>>);
+
+    impl ContainsGcs for Foo {
+        fn contains_gcs(&self, visitor: &mut ContainsGcsVisitor) -> bool {
+            if visitor.consume_fuel().is_err() {
+                return true;
+            }
+
+            self.0.contains_gcs(visitor)
+        }
+    }
 
     unsafe impl<V: Visitor> TraceWith<V> for Foo {
         #[inline]
@@ -118,6 +150,16 @@ fn self_referential() {
 fn cyclic() {
     static DROPPED: AtomicU8 = AtomicU8::new(0);
     struct Foo(RefCell<Option<Gc<Foo>>>);
+
+    impl ContainsGcs for Foo {
+        fn contains_gcs(&self, visitor: &mut ContainsGcsVisitor) -> bool {
+            if visitor.consume_fuel().is_err() {
+                return true;
+            }
+
+            self.0.contains_gcs(visitor)
+        }
+    }
 
     unsafe impl<V: Visitor> TraceWith<V> for Foo {
         #[inline]
@@ -306,6 +348,16 @@ fn escape_dead_pointer() {
         }
     }
 
+    impl ContainsGcs for Escape {
+        fn contains_gcs(&self, visitor: &mut ContainsGcsVisitor) -> bool {
+            if visitor.consume_fuel().is_err() {
+                return true;
+            }
+
+            self.ptr.contains_gcs(visitor)
+        }
+    }
+
     unsafe impl<V: Visitor> TraceWith<V> for Escape {
         fn accept(&self, visitor: &mut V) -> Result<(), ()> {
             self.ptr.accept(visitor)
@@ -365,6 +417,12 @@ fn from_slice_panic() {
                 value: self.value.clone(),
                 panic: self.panic,
             }
+        }
+    }
+
+    impl ContainsGcs for MayPanicOnClone {
+        fn contains_gcs(&self, _: &mut ContainsGcsVisitor) -> bool {
+            false
         }
     }
 
@@ -460,6 +518,16 @@ fn make_mut_of_object_in_dumpster() {
         something: Gc<i32>,
     }
 
+    impl ContainsGcs for Foo {
+        fn contains_gcs(&self, visitor: &mut ContainsGcsVisitor) -> bool {
+            if visitor.consume_fuel().is_err() {
+                return true;
+            }
+
+            self.something.contains_gcs(visitor)
+        }
+    }
+
     unsafe impl<V: Visitor> TraceWith<V> for Foo {
         fn accept(&self, visitor: &mut V) -> Result<(), ()> {
             self.something.accept(visitor)
@@ -494,6 +562,12 @@ fn make_mut_of_object_in_dumpster() {
 fn panic_visit() {
     struct PanicVisit;
 
+    impl ContainsGcs for PanicVisit {
+        fn contains_gcs(&self, _: &mut ContainsGcsVisitor) -> bool {
+            panic!("panic on visit");
+        }
+    }
+
     /// We technically can make it part of the contract for `Trace` to reject panicking impls,
     /// but it is good form to accept these even though they are malformed.
     unsafe impl<V: Visitor> TraceWith<V> for PanicVisit {
@@ -524,6 +598,16 @@ fn new_cyclic_one() {
     #[expect(unused)]
     struct Cycle(Gc<Self>, DropCount);
 
+    impl ContainsGcs for Cycle {
+        fn contains_gcs(&self, visitor: &mut ContainsGcsVisitor) -> bool {
+            if visitor.consume_fuel().is_err() {
+                return true;
+            }
+
+            self.0.contains_gcs(visitor)
+        }
+    }
+
     unsafe impl<V: Visitor> TraceWith<V> for Cycle {
         fn accept(&self, visitor: &mut V) -> Result<(), ()> {
             self.0.accept(visitor)
@@ -549,6 +633,16 @@ fn dead_inside_alive() {
     struct Cycle(Option<Gc<Self>>);
     thread_local! {
         static ESCAPE: Cell<Option<Gc<Cycle>>> = const { Cell::new(None) };
+    }
+
+    impl ContainsGcs for Cycle {
+        fn contains_gcs(&self, visitor: &mut ContainsGcsVisitor) -> bool {
+            if visitor.consume_fuel().is_err() {
+                return true;
+            }
+
+            self.0.contains_gcs(visitor)
+        }
     }
 
     unsafe impl<V: Visitor> TraceWith<V> for Cycle {
@@ -584,9 +678,29 @@ fn leak_by_creation_in_drop() {
     struct Foo(OnceCell<Gc<Self>>);
     struct Bar(OnceCell<Gc<Self>>);
 
+    impl ContainsGcs for Foo {
+        fn contains_gcs(&self, visitor: &mut ContainsGcsVisitor) -> bool {
+            if visitor.consume_fuel().is_err() {
+                return true;
+            }
+
+            self.0.contains_gcs(visitor)
+        }
+    }
+
     unsafe impl<V: Visitor> TraceWith<V> for Foo {
         fn accept(&self, visitor: &mut V) -> Result<(), ()> {
             self.0.accept(visitor)
+        }
+    }
+
+    impl ContainsGcs for Bar {
+        fn contains_gcs(&self, visitor: &mut ContainsGcsVisitor) -> bool {
+            if visitor.consume_fuel().is_err() {
+                return true;
+            }
+
+            self.0.contains_gcs(visitor)
         }
     }
 
@@ -646,6 +760,16 @@ fn unsync_fuzz() {
         fn drop(&mut self) {
             let n_drop = DROP_DETECTORS[self.id].fetch_add(1, Ordering::Relaxed);
             assert_eq!(n_drop, 0, "must not double drop an allocation");
+        }
+    }
+
+    impl ContainsGcs for Alloc {
+        fn contains_gcs(&self, visitor: &mut ContainsGcsVisitor) -> bool {
+            if visitor.consume_fuel().is_err() {
+                return true;
+            }
+
+            self.refs.contains_gcs(visitor)
         }
     }
 
@@ -763,6 +887,16 @@ fn self_referential_from_iter() {
     struct Ab {
         a: Gc<Self>,
         b: Gc<Self>,
+    }
+
+    impl ContainsGcs for Ab {
+        fn contains_gcs(&self, visitor: &mut ContainsGcsVisitor) -> bool {
+            if visitor.consume_fuel().is_err() {
+                return true;
+            }
+
+            self.a.contains_gcs(visitor) || self.b.contains_gcs(visitor)
+        }
     }
 
     unsafe impl<V: Visitor> TraceWith<V> for Ab {

--- a/dumpster_derive/Cargo.toml
+++ b/dumpster_derive/Cargo.toml
@@ -17,4 +17,5 @@ proc-macro = true
 proc-macro2 = "1.0.60"
 quote = "1.0"
 syn = "2.0"
+synstructure = "0.13.2"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/dumpster_derive/src/lib.rs
+++ b/dumpster_derive/src/lib.rs
@@ -43,19 +43,46 @@ fn derive_trace(mut s: synstructure::Structure) -> Result<TokenStream> {
     // Every field must implement `Trace` (but the generics don't).
     s.add_bounds(synstructure::AddBounds::Fields);
 
-    let match_arms = s.each(|bi| {
-        quote! {
-            #dumpster::TraceWith::accept(#bi, visitor)?;
-        }
-    });
+    let contains_gcs_body = {
+        let match_arms = s.each(|bi| {
+            quote! {
+                if #dumpster::ContainsGcs::contains_gcs(#bi, visitor) {
+                    return true;
+                }
+            }
+        });
 
-    let body = quote!(match *self { #match_arms });
+        quote!(match *self { #match_arms })
+    };
+
+    let trace_with_body = {
+        let match_arms = s.each(|bi| {
+            quote! {
+                #dumpster::TraceWith::accept(#bi, visitor)?;
+            }
+        });
+
+        quote!(match *self { #match_arms })
+    };
 
     Ok(s.gen_impl(quote! {
+        gen impl #dumpster::ContainsGcs for @Self {
+            #[inline]
+            fn contains_gcs(&self, visitor: &mut #dumpster::ContainsGcsVisitor) -> bool {
+                if visitor.consume_fuel().is_err() {
+                    return true;
+                }
+
+                #contains_gcs_body
+
+                false
+            }
+        }
+
         gen unsafe impl<__V: #dumpster::Visitor> #dumpster::TraceWith<__V> for @Self {
             #[inline]
             fn accept(&self, visitor: &mut __V) -> ::core::result::Result<(), ()> {
-                #body
+                #trace_with_body
                 ::core::result::Result::Ok(())
             }
         }

--- a/dumpster_derive/src/lib.rs
+++ b/dumpster_derive/src/lib.rs
@@ -11,198 +11,53 @@
 #![warn(clippy::cargo)]
 #![allow(clippy::multiple_crate_versions)]
 
-use proc_macro2::{TokenStream, TokenTree};
-use quote::{format_ident, quote, quote_spanned, ToTokens as _};
-use syn::{
-    parse_macro_input, parse_quote, spanned::Spanned, Data, DeriveInput, Fields, GenericParam,
-    Generics, Ident, Index, Path,
-};
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{parse_quote, Path, Result};
 
-#[proc_macro_derive(Trace, attributes(dumpster))]
-/// Derive `Trace` for a type.
-pub fn derive_trace(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    let input = parse_macro_input!(input as DeriveInput);
+synstructure::decl_derive!(
+    [Trace, attributes(dumpster)] =>
+    /// Derive `Trace` for a type.
+    derive_trace
+);
+
+fn derive_trace(mut s: synstructure::Structure) -> Result<TokenStream> {
     let mut dumpster: Path = parse_quote!(::dumpster);
 
     // look for `crate` argument
-    for attr in &input.attrs {
+    for attr in &s.ast().attrs {
         if !attr.path().is_ident("dumpster") {
             continue;
         }
 
-        let result = attr.parse_nested_meta(|meta| {
+        attr.parse_nested_meta(|meta| {
             if meta.path.is_ident("crate") {
                 dumpster = meta.value()?.parse()?;
                 Ok(())
             } else {
                 Err(meta.error("unsupported attribute"))
             }
-        });
-
-        if let Err(err) = result {
-            return err.into_compile_error().into();
-        }
+        })?;
     }
 
-    // name of the type being implemented
-    let name = &input.ident;
+    // Every field must implement `Trace` (but the generics don't).
+    s.add_bounds(synstructure::AddBounds::Fields);
 
-    // generic parameters of the type being implemented
-    let generics = add_trait_bounds(&dumpster, input.generics);
-    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+    let match_arms = s.each(|bi| {
+        quote! {
+            #dumpster::TraceWith::accept(#bi, visitor)?;
+        }
+    });
 
-    let impl_generics = {
-        let tokens = impl_generics.into_token_stream();
-        let param = quote! { __V: #dumpster::Visitor };
+    let body = quote!(match *self { #match_arms });
 
-        let params = if tokens.is_empty() {
-            quote! { #param }
-        } else {
-            // remove the angle bracket delimiters
-            let mut tokens: Vec<TokenTree> = tokens.into_iter().skip(1).collect();
-            tokens.pop();
-
-            let tokens: TokenStream = tokens.into_iter().collect();
-
-            quote! { #param, #tokens }
-        };
-
-        quote! { < #params > }
-    };
-
-    let do_visitor = delegate_methods(&dumpster, name, &input.data);
-
-    let generated = quote! {
-        unsafe impl #impl_generics #dumpster::TraceWith<__V> for #name #ty_generics #where_clause {
+    Ok(s.gen_impl(quote! {
+        gen unsafe impl<__V: #dumpster::Visitor> #dumpster::TraceWith<__V> for @Self {
             #[inline]
             fn accept(&self, visitor: &mut __V) -> ::core::result::Result<(), ()> {
-                #do_visitor
+                #body
+                ::core::result::Result::Ok(())
             }
         }
-    };
-
-    generated.into()
-}
-
-/// Collect the trait bounds for some generic expression.
-fn add_trait_bounds(dumpster: &Path, mut generics: Generics) -> Generics {
-    for param in &mut generics.params {
-        if let GenericParam::Type(ref mut type_param) = *param {
-            type_param
-                .bounds
-                .push(parse_quote!(#dumpster::TraceWith<__V>));
-        }
-    }
-    generics
-}
-
-#[allow(clippy::too_many_lines)]
-/// Generate method implementations for [`Trace`] for some data type.
-fn delegate_methods(dumpster: &Path, name: &Ident, data: &Data) -> TokenStream {
-    match data {
-        Data::Struct(data) => match data.fields {
-            Fields::Named(ref f) => {
-                let delegate_visit = f.named.iter().map(|f| {
-                    let name = &f.ident;
-                    quote_spanned! {f.span() =>
-                        #dumpster::TraceWith::accept(
-                            &self.#name,
-                            visitor
-                        )?;
-                    }
-                });
-
-                quote! { #(#delegate_visit)* ::core::result::Result::Ok(()) }
-            }
-            Fields::Unnamed(ref f) => {
-                let delegate_visit = f.unnamed.iter().enumerate().map(|(i, f)| {
-                    let index = Index::from(i);
-                    quote_spanned! {f.span() =>
-                        #dumpster::TraceWith::accept(
-                            &self.#index,
-                            visitor
-                        )?;
-                    }
-                });
-
-                quote! { #(#delegate_visit)* ::core::result::Result::Ok(()) }
-            }
-            Fields::Unit => quote! { ::core::result::Result::Ok(()) },
-        },
-        Data::Enum(e) => {
-            let mut delegate_visit = TokenStream::new();
-            for var in &e.variants {
-                let var_name = &var.ident;
-
-                match &var.fields {
-                    Fields::Named(n) => {
-                        let mut binding = TokenStream::new();
-                        let mut execution_visit = TokenStream::new();
-                        for (i, name) in n.named.iter().enumerate() {
-                            let field_name = format_ident!("field{i}");
-                            let field_ident = name.ident.as_ref().unwrap();
-                            if i == 0 {
-                                binding.extend(quote! {
-                                    #field_ident: #field_name
-                                });
-                            } else {
-                                binding.extend(quote! {
-                                    , #field_ident: #field_name
-                                });
-                            }
-
-                            execution_visit.extend(quote! {
-                                #dumpster::TraceWith::accept(
-                                    #field_name,
-                                    visitor
-                                )?;
-                            });
-                        }
-
-                        delegate_visit.extend(
-                            quote! {#name::#var_name{#binding} => {#execution_visit ::core::result::Result::Ok(())},},
-                        );
-                    }
-                    Fields::Unnamed(u) => {
-                        let mut binding = TokenStream::new();
-                        let mut execution_visit = TokenStream::new();
-                        for (i, _) in u.unnamed.iter().enumerate() {
-                            let field_name = format_ident!("field{i}");
-                            if i == 0 {
-                                binding.extend(quote! {
-                                    #field_name
-                                });
-                            } else {
-                                binding.extend(quote! {
-                                    , #field_name
-                                });
-                            }
-
-                            execution_visit.extend(quote! {
-                                #dumpster::TraceWith::accept(
-                                    #field_name,
-                                    visitor
-                                )?;
-                            });
-                        }
-
-                        delegate_visit.extend(
-                            quote! {#name::#var_name(#binding) => {#execution_visit ::core::result::Result::Ok(())},},
-                        );
-                    }
-                    Fields::Unit => {
-                        delegate_visit
-                            .extend(quote! {#name::#var_name => ::core::result::Result::Ok(()),});
-                    }
-                }
-            }
-
-            quote! {match self {#delegate_visit}}
-        }
-        Data::Union(u) => {
-            quote_spanned! {
-                u.union_token.span => compile_error!("`Trace` must be manually implemented for unions");
-            }
-        }
-    }
+    }))
 }

--- a/dumpster_test/src/lib.rs
+++ b/dumpster_test/src/lib.rs
@@ -13,11 +13,14 @@
 
 use std::{
     cell::RefCell,
+    marker::PhantomData,
     sync::atomic::{AtomicU8, AtomicUsize, Ordering},
 };
 
-use dumpster::unsync::{collect, Gc};
-use dumpster_derive::Trace;
+use dumpster::{
+    unsync::{collect, Gc},
+    Trace,
+};
 
 #[derive(Trace)]
 struct Empty;
@@ -183,4 +186,24 @@ fn unsync_as_ptr() {
     assert_ne!(empty_ptr, Gc::as_ptr(&b2.0));
     assert_ne!(Gc::as_ptr(&b.0), Gc::as_ptr(&b2.0));
     assert_ne!(Gc::as_ptr(&b.0), empty2_ptr);
+}
+
+#[test]
+fn derive_trace_has_field_bounds_not_generic_bounds() {
+    const fn implements_trace(_: &impl Trace) {}
+
+    struct DoesNotImplTrace;
+
+    // All fields of this type implement `Trace` regardless of `T`
+    // so the struct also implements `Trace` regardless of `T`.
+    #[derive(Trace)]
+    struct GenericStruct<T> {
+        fn_ptr: fn(T) -> T,
+        phantom: PhantomData<T>,
+    }
+
+    implements_trace(&GenericStruct::<DoesNotImplTrace> {
+        fn_ptr: |x| x,
+        phantom: PhantomData,
+    });
 }

--- a/dumpster_test/src/lib.rs
+++ b/dumpster_test/src/lib.rs
@@ -188,12 +188,13 @@ fn unsync_as_ptr() {
     assert_ne!(Gc::as_ptr(&b.0), empty2_ptr);
 }
 
-#[test]
-fn derive_trace_has_field_bounds_not_generic_bounds() {
-    const fn implements_trace(_: &impl Trace) {}
+const fn assert_implements_trace(_: &impl Trace) {}
 
-    struct DoesNotImplTrace;
+/// Some struct that doesn't implement `Trace`.
+struct DoesNotImplTrace;
 
+// A generic struct should not have a `Trace` bound for each generic, but for the fields instead.
+const _: () = {
     // All fields of this type implement `Trace` regardless of `T`
     // so the struct also implements `Trace` regardless of `T`.
     #[derive(Trace)]
@@ -202,8 +203,8 @@ fn derive_trace_has_field_bounds_not_generic_bounds() {
         phantom: PhantomData<T>,
     }
 
-    implements_trace(&GenericStruct::<DoesNotImplTrace> {
+    assert_implements_trace(&GenericStruct::<DoesNotImplTrace> {
         fn_ptr: |x| x,
         phantom: PhantomData,
     });
-}
+};


### PR DESCRIPTION
This would significantly improve performance (#80).
Alternately: could we instead modify `Trace` to support arbitrary control flow management?

- **feat!: change `TraceWith` trait bounds to be on the field types and not on generics when deriving `Trace`**
- **test: improve derive `Trace` test**
- **feat!: add `ContainsGcs` trait**
