### PR TITLE
feat: downcast_gc! macro for downcasting from a `dyn Any`

### DIFF
--- a/dumpster/src/sync/mod.rs
+++ b/dumpster/src/sync/mod.rs
@@ -41,14 +41,13 @@ use loom::{
     lazy_static,
     sync::atomic::{fence, AtomicUsize, Ordering},
 };
-use std::fmt::Display;
 #[cfg(not(loom))]
 use std::sync::atomic::{fence, AtomicUsize, Ordering};
 use std::{
     alloc::{dealloc, handle_alloc_error, Layout},
     any::TypeId,
     borrow::{Borrow, Cow},
-    fmt::Debug,
+    fmt::{Debug, Display},
     mem::{self, ManuallyDrop, MaybeUninit},
     num::NonZeroUsize,
     ops::Deref,
@@ -771,6 +770,8 @@ impl<T: Trace + Send + Sync + Clone> Gc<T> {
 ///
 /// This is one of two easy ways to create a `Gc<[T]>`; the other method is to use [`FromIterator`].
 ///
+/// To recover a sized `Gc<U>` from an unsized `Gc<T>`, use [`downcast_gc!`].
+///
 /// # Examples
 ///
 /// ```
@@ -803,6 +804,102 @@ macro_rules! __sync_coerce_gc {
 
 #[doc(inline)]
 pub use crate::__sync_coerce_gc as coerce_gc;
+
+/// Attempt to downcast a `Gc<T>` to a `Gc<U>`.
+///
+/// Returns `Result<Gc<U>, Gc<T>>`. On success, meaning the value behind the `Gc` is actually of
+/// type `U`. The original allocation (and its reference count) is preserved. On failure, the
+/// original `Gc<T>` is returned unchanged in the `Err` variant.
+///
+/// This is the inverse of [`coerce_gc!`]: where `coerce_gc!` unsize-coerces a `Gc<T>` into
+/// `Gc<dyn Trait>`, `downcast_gc!` recovers the original sized `Gc<T>`. The source `T` must
+/// therefore be unsized (e.g., `dyn Trait`; using `downcast_gc!` on an already
+/// sized `Gc` is a compile error.
+///
+/// The type check is performed via [`Any`](core::any::Any), so `T` must be castable to `&dyn Any`.
+/// In practice, this means that the trait object's trait should extend `Any`.
+///
+/// # Examples
+///
+/// Downcasting from a trait object back to its concrete type:
+///
+/// ```
+/// use dumpster::{
+///     sync::{coerce_gc, downcast_gc, Gc},
+///     Trace,
+/// };
+/// use std::any::Any;
+///
+/// trait MyTrait: Trace + Any + Send + Sync {}
+/// impl<T: Trace + Any + Send + Sync> MyTrait for T {}
+///
+/// let gc: Gc<dyn MyTrait> = coerce_gc!(Gc::new(5i32));
+/// let gc: Gc<i32> = downcast_gc!(gc, i32).ok().unwrap();
+/// assert_eq!(*gc, 5);
+/// ```
+///
+/// A failed downcast returns the original `Gc` in the `Err` variant:
+///
+/// ```
+/// use dumpster::{
+///     sync::{coerce_gc, downcast_gc, Gc},
+///     Trace,
+/// };
+/// use std::any::Any;
+///
+/// trait MyTrait: Trace + Any + Send + Sync {}
+/// impl<T: Trace + Any + Send + Sync> MyTrait for T {}
+///
+/// let gc: Gc<dyn MyTrait> = coerce_gc!(Gc::new(5i32));
+/// let gc: Gc<dyn MyTrait> = downcast_gc!(gc, u8).err().unwrap();
+/// // `gc` is still usable as a `Gc<dyn MyTrait>`.
+/// ```
+///
+/// Downcasting a sized `Gc` is rejected at compile time:
+///
+/// ```compile_fail
+/// use dumpster::sync::{downcast_gc, Gc};
+///
+/// let gc: Gc<i32> = Gc::new(5);
+/// let _ = downcast_gc!(gc, i32);
+/// ```
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __sync_downcast_gc {
+    ($gc:expr, $t:ty) => {{
+        match $crate::sync::assert_unsized($gc) {
+            gc if (::core::ops::Deref::deref(&gc) as &dyn ::core::any::Any).is::<$t>() => {
+                let (ptr, tag) = $crate::sync::Gc::__private_into_ptr(gc);
+                Ok(unsafe {
+                    $crate::sync::Gc::__private_from_ptr(ptr.cast::<$crate::sync::GcBox<$t>>(), tag)
+                })
+            }
+            gc => Err(gc),
+        }
+    }};
+}
+
+// Compile-time check: refuse to downcast an already-sized `Gc`. Fat pointers
+// (`&dyn Trait`, `&[T]`, `&str`) are wider than thin pointers; if `&T` is the size of
+// a thin pointer, then `T` is sized.
+#[doc(hidden)]
+pub const fn assert_unsized<T>(t: Gc<T>) -> Gc<T>
+where
+    T: Trace + ::core::marker::Send + ::core::marker::Sync + ?Sized + 'static,
+{
+    const {
+        assert!(
+            ::core::mem::size_of::<&T>() != ::core::mem::size_of::<*const ()>(),
+            "downcast_gc!: source `Gc` must hold an unsized type \
+                (e.g. `Gc<dyn Trait>`)",
+        );
+    }
+
+    t
+}
+
+#[doc(inline)]
+pub use crate::__sync_downcast_gc as downcast_gc;
 
 impl<T> Clone for Gc<T>
 where

--- a/dumpster/src/sync/tests.rs
+++ b/dumpster/src/sync/tests.rs
@@ -18,7 +18,10 @@ use std::{
 
 use foldhash::{HashMap, HashMapExt};
 
-use crate::{sync::coerce_gc, Visitor};
+use crate::{
+    sync::{coerce_gc, downcast_gc},
+    Visitor,
+};
 
 use super::*;
 
@@ -954,4 +957,63 @@ fn self_referential_from_iter() {
         gcs.push(Gc::new_cyclic(|a: Gc<Ab>| Ab { a, b }));
     }
     let _big_gc = gcs.into_iter().collect::<Gc<[_]>>();
+}
+
+trait MyTrait: crate::Trace + std::any::Any + Send + Sync {
+    fn val(&self) -> i64;
+}
+
+impl MyTrait for i32 {
+    fn val(&self) -> i64 {
+        i64::from(*self)
+    }
+}
+
+impl MyTrait for u8 {
+    fn val(&self) -> i64 {
+        i64::from(*self)
+    }
+}
+
+#[test]
+fn downcast_success() {
+    let gc: Gc<dyn MyTrait> = coerce_gc!(Gc::new(42i32));
+    let gc = downcast_gc!(gc, i32)
+        .ok()
+        .expect("downcast to i32 should succeed");
+    assert_eq!(*gc, 42);
+}
+
+#[test]
+fn downcast_wrong_type_returns_self() {
+    let gc: Gc<dyn MyTrait> = coerce_gc!(Gc::new(42i32));
+    let gc = downcast_gc!(gc, u8)
+        .err()
+        .expect("downcast to wrong type should fail");
+    // original trait object is still usable
+    assert_eq!(gc.val(), 42);
+}
+
+#[test]
+fn downcast_preserves_refcount() {
+    let gc: Gc<i32> = Gc::new(7i32);
+    let trait_gc: Gc<dyn MyTrait> = coerce_gc!(gc.clone());
+    assert_eq!(Gc::ref_count(&gc).get(), 2);
+
+    let recovered = downcast_gc!(trait_gc, i32).ok().unwrap();
+    assert_eq!(Gc::ref_count(&gc).get(), 2);
+    assert!(Gc::ptr_eq(&gc, &recovered));
+    assert_eq!(*recovered, 7);
+}
+
+#[test]
+fn downcast_failure_preserves_refcount() {
+    let gc: Gc<i32> = Gc::new(7i32);
+    let trait_gc: Gc<dyn MyTrait> = coerce_gc!(gc.clone());
+    assert_eq!(Gc::ref_count(&gc).get(), 2);
+
+    let trait_gc = downcast_gc!(trait_gc, u8).err().unwrap();
+    assert_eq!(Gc::ref_count(&gc).get(), 2);
+    drop(trait_gc);
+    assert_eq!(Gc::ref_count(&gc).get(), 1);
 }

--- a/dumpster/src/unsync/mod.rs
+++ b/dumpster/src/unsync/mod.rs
@@ -753,6 +753,8 @@ impl<T: Trace> Gc<[T]> {
 ///
 /// This is one of two easy ways to create a `Gc<[T]>`; the other method is to use [`FromIterator`].
 ///
+/// To recover a sized `Gc<U>` from an unsized `Gc<T>`, use [`downcast_gc!`].
+///
 /// # Examples
 ///
 /// ```
@@ -785,6 +787,102 @@ macro_rules! __unsync_coerce_gc {
 
 #[doc(inline)]
 pub use crate::__unsync_coerce_gc as coerce_gc;
+
+/// Attempt to downcast a `Gc<T>` to a `Gc<U>`.
+///
+/// Returns `Result<Gc<U>, Gc<T>>`. On success, meaning the value behind the `Gc` is actually of
+/// type `U`. The original allocation (and its reference count) is preserved. On failure, the
+/// original `Gc<T>` is returned unchanged in the `Err` variant.
+///
+/// This is the inverse of [`coerce_gc!`]: where `coerce_gc!` unsize-coerces a `Gc<T>` into
+/// `Gc<dyn Trait>`, `downcast_gc!` recovers the original sized `Gc<T>`. The source `T` must
+/// therefore be unsized (e.g., `dyn Trait`; using `downcast_gc!` on an already
+/// sized `Gc` is a compile error.
+///
+/// The type check is performed via [`Any`](core::any::Any), so `T` must be castable to `&dyn Any`.
+/// In practice, this means that the trait object's trait should extend `Any`.
+///
+/// # Examples
+///
+/// Downcasting from a trait object back to its concrete type:
+///
+/// ```
+/// use dumpster::{
+///     unsync::{coerce_gc, downcast_gc, Gc},
+///     Trace,
+/// };
+/// use std::any::Any;
+///
+/// trait MyTrait: Trace + Any {}
+/// impl<T: Trace + Any> MyTrait for T {}
+///
+/// let gc: Gc<dyn MyTrait> = coerce_gc!(Gc::new(5i32));
+/// let gc: Gc<i32> = downcast_gc!(gc, i32).ok().unwrap();
+/// assert_eq!(*gc, 5);
+/// ```
+///
+/// A failed downcast returns the original `Gc` in the `Err` variant:
+///
+/// ```
+/// use dumpster::{
+///     unsync::{coerce_gc, downcast_gc, Gc},
+///     Trace,
+/// };
+/// use std::any::Any;
+///
+/// trait MyTrait: Trace + Any {}
+/// impl<T: Trace + Any> MyTrait for T {}
+///
+/// let gc: Gc<dyn MyTrait> = coerce_gc!(Gc::new(5i32));
+/// let gc: Gc<dyn MyTrait> = downcast_gc!(gc, u8).err().unwrap();
+/// // `gc` is still usable as a `Gc<dyn MyTrait>`.
+/// ```
+///
+/// Downcasting a sized `Gc` is rejected at compile time:
+///
+/// ```compile_fail
+/// use dumpster::unsync::{downcast_gc, Gc};
+///
+/// let gc: Gc<i32> = Gc::new(5);
+/// let _ = downcast_gc!(gc, i32);
+/// ```
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __unsync_downcast_gc {
+    ($gc:expr, $t:ty) => {{
+        match $crate::unsync::assert_unsized($gc) {
+            gc if (::core::ops::Deref::deref(&gc) as &dyn ::core::any::Any).is::<$t>() => {
+                let ptr = $crate::unsync::Gc::__private_into_ptr(gc);
+                Ok(unsafe {
+                    $crate::unsync::Gc::__private_from_ptr(ptr.cast::<$crate::unsync::GcBox<$t>>())
+                })
+            }
+            gc => Err(gc),
+        }
+    }};
+}
+
+// Compile-time check: refuse to downcast an already-sized `Gc`. Fat pointers
+// (`&dyn Trait`, `&[T]`, `&str`) are wider than thin pointers; if `&T` is the size of
+// a thin pointer, then `T` is sized.
+#[doc(hidden)]
+pub const fn assert_unsized<T>(t: Gc<T>) -> Gc<T>
+where
+    T: Trace + ?Sized + 'static,
+{
+    const {
+        assert!(
+            ::core::mem::size_of::<&T>() != ::core::mem::size_of::<*const ()>(),
+            "downcast_gc!: source `Gc` must hold an unsized type \
+                (e.g. `Gc<dyn Trait>`)",
+        );
+    }
+
+    t
+}
+
+#[doc(inline)]
+pub use crate::__unsync_downcast_gc as downcast_gc;
 
 impl<T: Trace + ?Sized> Deref for Gc<T> {
     type Target = T;

--- a/dumpster/src/unsync/tests.rs
+++ b/dumpster/src/unsync/tests.rs
@@ -10,7 +10,10 @@
 
 use foldhash::{HashMap, HashMapExt};
 
-use crate::{unsync::coerce_gc, Visitor};
+use crate::{
+    unsync::{coerce_gc, downcast_gc},
+    Visitor,
+};
 
 use super::*;
 use std::{
@@ -782,4 +785,63 @@ fn self_referential_from_iter() {
         gcs.push(Gc::new_cyclic(|a: Gc<Ab>| Ab { a, b }));
     }
     let _big_gc = gcs.into_iter().collect::<Gc<[_]>>();
+}
+
+trait MyTrait: crate::Trace + std::any::Any {
+    fn val(&self) -> i64;
+}
+
+impl MyTrait for i32 {
+    fn val(&self) -> i64 {
+        i64::from(*self)
+    }
+}
+
+impl MyTrait for u8 {
+    fn val(&self) -> i64 {
+        i64::from(*self)
+    }
+}
+
+#[test]
+fn downcast_success() {
+    let gc: Gc<dyn MyTrait> = coerce_gc!(Gc::new(42i32));
+    let gc = downcast_gc!(gc, i32)
+        .ok()
+        .expect("downcast to i32 should succeed");
+    assert_eq!(*gc, 42);
+}
+
+#[test]
+fn downcast_wrong_type_returns_self() {
+    let gc: Gc<dyn MyTrait> = coerce_gc!(Gc::new(42i32));
+    let gc = downcast_gc!(gc, u8)
+        .err()
+        .expect("downcast to wrong type should fail");
+    // original trait object is still usable
+    assert_eq!(gc.val(), 42);
+}
+
+#[test]
+fn downcast_preserves_refcount() {
+    let gc: Gc<i32> = Gc::new(7i32);
+    let trait_gc: Gc<dyn MyTrait> = coerce_gc!(gc.clone());
+    assert_eq!(Gc::ref_count(&gc).get(), 2);
+
+    let recovered = downcast_gc!(trait_gc, i32).ok().unwrap();
+    assert_eq!(Gc::ref_count(&gc).get(), 2);
+    assert!(Gc::ptr_eq(&gc, &recovered));
+    assert_eq!(*recovered, 7);
+}
+
+#[test]
+fn downcast_failure_preserves_refcount() {
+    let gc: Gc<i32> = Gc::new(7i32);
+    let trait_gc: Gc<dyn MyTrait> = coerce_gc!(gc.clone());
+    assert_eq!(Gc::ref_count(&gc).get(), 2);
+
+    let trait_gc = downcast_gc!(trait_gc, u8).err().unwrap();
+    assert_eq!(Gc::ref_count(&gc).get(), 2);
+    drop(trait_gc);
+    assert_eq!(Gc::ref_count(&gc).get(), 1);
 }


### PR DESCRIPTION
Adding a new trait to complement `coerce_gc!` except instead of coercing into a value it attempts to downcast from a `dyn Any` into some Sized type.